### PR TITLE
Do not fail build on missing issue number.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   comment-notification:
-    if: github.event_name == 'repository_dispatch'
+    if: github.event_name == 'repository_dispatch' && github.event.client_payload.github.payload.issue.number
     runs-on: ubuntu-latest
     steps:
       - name: Create URL to the run output


### PR DESCRIPTION
We do not want the build to fail in the event that the dispatch event
does not contain the issue number to for the comment-notification job.
In the event that the the field is missing, we will simply skip the
notification.