### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
       #     password: ${{ secrets.DOCKER_HUB_PASSWORD }}
   debian-sdk:
     name: Debian SDK images
-    needs: base
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -134,7 +133,6 @@ jobs:
             docker/${{ matrix.sdk }}
   ubi-sdk:
     name: UBI SDK images
-    needs: base
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -1,25 +1,26 @@
 # syntax = docker/dockerfile:experimental
-# Interim container so we can copy pulumi binaries
-# Must be defined first
-ARG PULUMI_VERSION=latest
-ARG PULUMI_IMAGE=pulumi/pulumi-base
-FROM ${PULUMI_IMAGE}:${PULUMI_VERSION} as pulumi
 
-# Build container
-FROM ubuntu:bionic AS builder
-WORKDIR /dotnet
+FROM debian:buster-slim AS builder
+ARG PULUMI_VERSION=latest
 RUN apt-get update -y && \
+    apt-get upgrade -y && \
     apt-get install -y \
     curl \
-    gpg
-RUN curl -o - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.asc.gpg; \
-    curl -o /tmp/microsoft-prod.list https://packages.microsoft.com/config/debian/10/prod.list
+    build-essential \
+    git
+
+# Install the Pulumi SDK, including the CLI and language runtimes.
+RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
+    curl -fsSL https://get.pulumi.com/ | bash; \
+    else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
+    fi
 
 # The runtime container
 FROM debian:buster-slim
 WORKDIR /pulumi/projects
 
-ARG DOTNET_RUNTIME_VERSION="3.1"
+ARG DOTNET_VERSION="3.1"
 
 RUN apt-get update -y && \
     apt-get install -y \
@@ -29,13 +30,13 @@ RUN apt-get update -y && \
 # arm64 packages are not available in apt-get, per
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian, so we need
 # to install via another method:
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -c ${DOTNET_RUNTIME_VERSION} && \
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -c ${DOTNET_VERSION} && \
     echo "PATH=$PATH:$HOME/.dotnet" >> ~/.bashrc && \
     echo "export DOTNET_ROOT=$HOME/.dotnet" >> ~/.bashrc
 
 # Uses the workdir, copies from pulumi interim container
-COPY --from=pulumi /pulumi/bin/pulumi /pulumi/bin/pulumi
-COPY --from=pulumi /pulumi/bin/*-dotnet* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
+COPY --from=builder /root/.pulumi/bin/*-dotnet* /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/dotnet/Dockerfile.ubi
+++ b/docker/dotnet/Dockerfile.ubi
@@ -1,13 +1,26 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
 ARG PULUMI_VERSION=latest
-ARG PULUMI_IMAGE=pulumi/pulumi-base
-FROM ${PULUMI_IMAGE}:${PULUMI_VERSION}-ubi as pulumi
+RUN microdnf install -y \
+    curl \
+    make \
+    gcc \
+    git \
+    tar \
+    gcc-c++
+# Install the Pulumi SDK, including the CLI and language runtimes.
+RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
+    curl -fsSL https://get.pulumi.com/ | bash; \
+    else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
+    fi
+
 
 # The runtime container
 FROM redhat/ubi8-minimal:latest
-ARG DOTNET_RUNTIME_VERSION=3.1
+ARG DOTNET_VERSION=3.1
 WORKDIR /pulumi/projects
 
 RUN microdnf install -y \
@@ -20,14 +33,14 @@ RUN microdnf install -y \
 
 # arm64 packages are not available for 3.1 (at least, possibly later versions as
 # well), so we need to install via another method:
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -c ${DOTNET_RUNTIME_VERSION} && \
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -c ${DOTNET_VERSION} && \
     echo "PATH=$PATH:$HOME/.dotnet" >> ~/.bashrc && \
     echo "export DOTNET_ROOT=$HOME/.dotnet" >> ~/.bashrc
 
 
 # Uses the workdir, copies from pulumi interim container
-COPY --from=pulumi /pulumi/bin/pulumi /pulumi/bin/pulumi
-COPY --from=pulumi /pulumi/bin/*-dotnet* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
+COPY --from=builder /root/.pulumi/bin/*-dotnet* /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -1,9 +1,21 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
+FROM debian:buster-slim AS builder
 ARG PULUMI_VERSION=latest
-ARG PULUMI_IMAGE=pulumi/pulumi-base
-FROM ${PULUMI_IMAGE}:${PULUMI_VERSION} as pulumi
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    curl \
+    build-essential \
+    git
+
+# Install the Pulumi SDK, including the CLI and language runtimes.
+RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
+    curl -fsSL https://get.pulumi.com/ | bash; \
+    else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
+    fi
 
 # The runtime container
 FROM node:lts-buster-slim
@@ -16,9 +28,9 @@ RUN apt-get update -y && \
     ca-certificates
 
 # Uses the workdir, copies from pulumi interim container
-COPY --from=pulumi /pulumi/bin/pulumi /pulumi/bin/pulumi
-COPY --from=pulumi /pulumi/bin/*-nodejs* /pulumi/bin/
-COPY --from=pulumi /pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
+COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -1,9 +1,21 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
 ARG PULUMI_VERSION=latest
-ARG PULUMI_IMAGE=pulumi/pulumi-base
-FROM ${PULUMI_IMAGE}:${PULUMI_VERSION} as pulumi
+RUN microdnf install -y \
+    curl \
+    make \
+    gcc \
+    git \
+    tar \
+    gcc-c++
+# Install the Pulumi SDK, including the CLI and language runtimes.
+RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
+    curl -fsSL https://get.pulumi.com/ | bash; \
+    else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
+    fi
 
 # The runtime container
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
@@ -11,8 +23,7 @@ WORKDIR /pulumi/projects
 
 COPY dnf/nodejs.module /etc/dnf/modules.d/nodejs.module
 
-RUN --mount=target=/var/cache/yum,type=cache \
-    microdnf install -y \
+RUN microdnf install -y \
     git \
     tar \
     nodejs \
@@ -20,9 +31,9 @@ RUN --mount=target=/var/cache/yum,type=cache \
     npm install -g yarn
 
 # Uses the workdir, copies from pulumi interim container
-COPY --from=pulumi /pulumi/bin/pulumi /pulumi/bin/pulumi
-COPY --from=pulumi /pulumi/bin/*-nodejs* /pulumi/bin/
-COPY --from=pulumi /pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
+COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,13 +1,26 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
+ARG PYTHON_VERSION=3.9
+
+FROM debian:buster-slim AS builder
 ARG PULUMI_VERSION=latest
-ARG RUNTIME_VERSION=3.9
-ARG PULUMI_IMAGE=pulumi/pulumi-base
-FROM ${PULUMI_IMAGE}:${PULUMI_VERSION} as pulumi
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    curl \
+    build-essential \
+    git
+
+# Install the Pulumi SDK, including the CLI and language runtimes.
+RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
+    curl -fsSL https://get.pulumi.com/ | bash; \
+    else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
+    fi
 
 # The runtime container
-FROM python:${RUNTIME_VERSION}-slim-buster
+FROM python:${PYTHON_VERSION}-slim-buster
 WORKDIR /pulumi/projects
 
 # Install needed tools, like git
@@ -17,8 +30,8 @@ RUN apt-get update -y && \
     ca-certificates
 
 # Uses the workdir, copies from pulumi interim container
-COPY --from=pulumi /pulumi/bin/pulumi /pulumi/bin/pulumi
-COPY --from=pulumi /pulumi/bin/*-python* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
+COPY --from=builder /root/.pulumi/bin/*-python* /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/python/Dockerfile.ubi
+++ b/docker/python/Dockerfile.ubi
@@ -1,17 +1,27 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
 ARG PULUMI_VERSION=latest
-ARG PULUMI_IMAGE=pulumi/pulumi-base
-FROM ${PULUMI_IMAGE}:${PULUMI_VERSION} as pulumi
-
+RUN microdnf install -y \
+    curl \
+    make \
+    gcc \
+    git \
+    tar \
+    gcc-c++
+# Install the Pulumi SDK, including the CLI and language runtimes.
+RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
+    curl -fsSL https://get.pulumi.com/ | bash; \
+    else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
+    fi
 # The runtime container
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /pulumi/projects
 
 # Install needed tools, like git
-RUN --mount=target=/var/cache/yum,type=cache \
-    microdnf install -y \
+RUN microdnf install -y \
     git \
     tar \
     python3 \
@@ -20,8 +30,8 @@ RUN --mount=target=/var/cache/yum,type=cache \
     pip3 install --user pipenv
 
 # Uses the workdir, copies from pulumi interim container
-COPY --from=pulumi /pulumi/bin/pulumi /pulumi/bin/pulumi
-COPY --from=pulumi /pulumi/bin/*-python* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
+COPY --from=builder /root/.pulumi/bin/*-python* /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]


### PR DESCRIPTION
CI builds build, but do not push images.  The SDK builds, prior to this change, depended on the pulumi-base image being present in Docker Hub.  By removing this dependency, CI builds only depend on a Pulumi binary via get.pulumi.com rather than the pulumi-base Docker image.  We also  allow greater parallelism in the build process.