### PR TITLE
Re-remove the needs: clause from CI builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
       #     password: ${{ secrets.DOCKER_HUB_PASSWORD }}
   debian-sdk:
     name: Debian SDK images
-    needs: base
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -134,7 +133,6 @@ jobs:
             docker/${{ matrix.sdk }}
   ubi-sdk:
     name: UBI SDK images
-    needs: base
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This change got re-added as a first attempt to fix the CI build, but we
forgot to rebase on #30, and thus need to re-remove it.