### PR TITLE
Add tests for UBI SDK containers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }} # Used by test-containers.sh
+  PULUMI_ORG: "pulumi-test"
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
   # We parameterize the Docker Hub username to allow forks to easily test
   # changes on a separate repo without having to change the username in multiple
@@ -46,7 +47,7 @@ jobs:
 
             [1]: ${{ steps.vars.outputs.run-url }}
   test-containers:
-    name: Test Container Changes
+    name: Test All SDKs container
     # Verify that the event is not triggered by a fork since forks cannot
     # access secrets other than the default GITHUB_TOKEN.
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -163,6 +164,37 @@ jobs:
             -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
             docker/${{ matrix.sdk }}
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16.9"
+      - name: Compile tests
+        working-directory: tests
+        run: |
+          GOOS=linux GOARCH=amd64 go test -c -o /tmp/pulumi-test-containers ./...
+
+      - name: Set SDKS_TO_TEST (dotnet)
+        if: ${{ matrix.sdk == 'dotnet' }}
+        run: echo "SDKS_TO_TEST=csharp" >> $GITHUB_ENV
+      - name: Set SDKS_TO_TEST (nodejs)
+        if: ${{ matrix.sdk == 'nodejs' }}
+        run: echo "SDKS_TO_TEST=typescript" >> $GITHUB_ENV
+      - name: Set SDKS_TO_TEST (default)
+        if: ${{ matrix.sdk != 'dotnet' && matrix.sdk != 'nodejs' }}
+        run: echo "SDKS_TO_TEST=${{ matrix.sdk}}" >> $GITHUB_ENV \
+
+      - name: Run tests
+        run: |
+          docker run \
+            -e RUN_CONTAINER_TESTS=true \
+            -e SDKS_TO_TEST=${SDKS_TO_TEST} \
+            -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e PULUMI_ORG=${PULUMI_ORG} \
+            --volume /tmp:/src \
+            --entrypoint /bin/bash \
+            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            -c "/src/pulumi-test-containers -test.parallel=1 -test.timeout=1h -test.v -test.run TestPulumiDockerImage"
+
       # - name: Build image
       #   uses: pulumi/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
       #   with:

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -30,13 +30,14 @@ RUN apt-get update -y && \
 # arm64 packages are not available in apt-get, per
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian, so we need
 # to install via another method:
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -c ${DOTNET_VERSION} && \
-    echo "PATH=$PATH:$HOME/.dotnet" >> ~/.bashrc && \
-    echo "export DOTNET_ROOT=$HOME/.dotnet" >> ~/.bashrc
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -c ${DOTNET_VERSION}
 
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-dotnet* /pulumi/bin/
-ENV PATH "/pulumi/bin:${PATH}"
+
+ENV PATH "/root/.dotnet:/pulumi/bin:${PATH}"
+ENV DOTNET_ROOT /root/.dotnet
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 
 CMD ["pulumi"]

--- a/scripts/test-containers.sh
+++ b/scripts/test-containers.sh
@@ -41,6 +41,7 @@ popd
 # and working correctly.
 docker run -e RUN_CONTAINER_TESTS=true \
     -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+    -e PULUMI_ORG=${PULUMI_ORG} \
     --volume /tmp:/src \
     --entrypoint /bin/bash \
     pulumi/pulumi:latest \

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -15,6 +15,7 @@ package containers
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,8 +27,6 @@ import (
 //
 // NOTE: This test is intended to be run inside the aforementioned container, unlike the actions test below.
 func TestPulumiDockerImage(t *testing.T) {
-	const stackOwner = "moolumi"
-
 	if os.Getenv("RUN_CONTAINER_TESTS") == "" {
 		t.Skip("Skipping container runtime tests because RUN_CONTAINER_TESTS not set.")
 	}
@@ -35,6 +34,16 @@ func TestPulumiDockerImage(t *testing.T) {
 	// Confirm we have credentials.
 	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
 		t.Fatal("PULUMI_ACCESS_TOKEN not found, aborting tests.")
+	}
+
+	var stackOwner = os.Getenv("PULUMI_ORG")
+	if stackOwner == "" {
+		t.Fatal("PULUMI_ORG must be set.  Aborting tests.")
+	}
+
+	sdksToTest := []string{"csharp", "python", "typescript", "go"}
+	if os.Getenv("SDKS_TO_TEST") != "" {
+		sdksToTest = strings.Split(os.Getenv("SDKS_TO_TEST"), ",")
 	}
 
 	base := integration.ProgramTestOptions{
@@ -45,7 +54,7 @@ func TestPulumiDockerImage(t *testing.T) {
 		NoParallel:           true, // we mark tests as Parallel manually when instantiating
 	}
 
-	for _, template := range []string{"csharp", "python", "typescript"} {
+	for _, template := range sdksToTest {
 		t.Run(template, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Prior to this change, an integration test suite only operated on the
"kitchen sink" pulumi/pulumi image which contains all 4 supported SDKs
for Pulumi.  This change adds the ability to run the tests for a subset
of SDKs, along with actually running the appropriate test suite for the
SDK-specific Docker images during the CI build.