### PR TITLE
Fix golang image.

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,13 +1,12 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
-ARG PULUMI_VERSION=latest
 
 # Build container
 FROM ubuntu:bionic AS builder
 
-# Set go versions
-ARG RUNTIME_VERSION=1.16.9
+ARG PULUMI_VERSION=latest
+ARG GO_RUNTIME_VERSION=1.16.10
 
 WORKDIR /golang
 RUN apt-get update -y && \
@@ -37,7 +36,7 @@ RUN case $(uname -m) in \
     ARCH=$(uname -m) \
     ;; \
     esac && \
-    curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${RUNTIME_VERSION}.linux-${ARCH}.tar.gz; \
+    curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${GO_RUNTIME_VERSION}.linux-${ARCH}.tar.gz; \
     mkdir -p bin; \
     tar -C /golang -xzf /tmp/go.tgz; \
     rm /tmp/go.tgz; \


### PR DESCRIPTION
The PULUMI_VERSION arg was defined before the FROM directive in the
build container.  We believe this caused "latest" to be the value read
by the line that installs Pulumi, and thus led to a mismatch between a
tagged image and the version of Pulumi installed on the image.
(get.pulumi.com does not update the latest version until after the docs
are published, but the Docker images' release build fires before the
docs are updated.)

Fixes #71 