### PR TITLE
Make PULUMI_VERSION a required argument.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 FROM debian:11-slim AS builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y \
@@ -9,11 +9,7 @@ RUN apt-get update -y && \
   git
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-  curl -fsSL https://get.pulumi.com/ | bash; \
-  else \
-  curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-  fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
 # This is our base container, so let's copy all the runtimes to .pulumi/bin

--- a/docker/base/Dockerfile.ubi
+++ b/docker/base/Dockerfile.ubi
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 FROM redhat/ubi8-minimal:latest as builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN microdnf install -y \
   curl \
   make \
@@ -9,11 +9,7 @@ RUN microdnf install -y \
   tar \
   gcc-c++
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-  curl -fsSL https://get.pulumi.com/ | bash; \
-  else \
-  curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-  fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
 # This is our base container, so let's copy all the runtimes to .pulumi/bin

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 
 FROM debian:11-slim AS builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y \
@@ -10,11 +10,8 @@ RUN apt-get update -y && \
     git
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
+
 
 # The runtime container
 FROM debian:11-slim

--- a/docker/dotnet/Dockerfile.ubi
+++ b/docker/dotnet/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 # Must be defined first
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN microdnf install -y \
     curl \
     make \
@@ -10,12 +10,9 @@ RUN microdnf install -y \
     git \
     tar \
     gcc-c++
+
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 
 # The runtime container

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -5,7 +5,7 @@
 # Build container
 FROM ubuntu:bionic AS builder
 
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 ARG GO_RUNTIME_VERSION=1.16.10
 
 WORKDIR /golang
@@ -18,12 +18,7 @@ RUN apt-get update -y && \
     git
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
-
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 RUN case $(uname -m) in \
     aarch64) \

--- a/docker/go/Dockerfile.ubi
+++ b/docker/go/Dockerfile.ubi
@@ -2,7 +2,7 @@
 
 # Build container
 FROM redhat/ubi8-minimal:latest as builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN microdnf install -y \
     curl \
     make \
@@ -12,11 +12,7 @@ RUN microdnf install -y \
     gcc-c++
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # Set go versions
 ARG RUNTIME_VERSION=1.16.2

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 # Must be defined first
 FROM debian:bullseye-slim AS builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y \
@@ -11,11 +11,8 @@ RUN apt-get update -y && \
     git
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
+
 
 # The runtime container
 FROM node:lts-bullseye-slim

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 # Must be defined first
 FROM redhat/ubi8-minimal:latest as builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN microdnf install -y \
     curl \
     make \
@@ -11,11 +11,7 @@ RUN microdnf install -y \
     tar \
     gcc-c++
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
 FROM redhat/ubi8-minimal:latest

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -85,14 +85,10 @@ RUN curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-
 # Passing --build-arg PULUMI_VERSION=vX.Y.Z will use that version
 # of the SDK. Otherwise, we use whatever get.pulumi.com thinks is
 # the latest
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-  curl -fsSL https://get.pulumi.com/ | bash; \
-  else \
-  curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-  fi && \
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION && \
   mv ~/.pulumi/bin/* /usr/bin
 
 # I think it's safe to say if we're using this mega image, we want pulumi

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -4,7 +4,7 @@
 ARG PYTHON_VERSION=3.9
 
 FROM debian:buster-slim AS builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y \
@@ -13,11 +13,7 @@ RUN apt-get update -y && \
     git
 
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
 FROM python:${PYTHON_VERSION}-slim

--- a/docker/python/Dockerfile.ubi
+++ b/docker/python/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 # Must be defined first
 FROM redhat/ubi8-minimal:latest as builder
-ARG PULUMI_VERSION=latest
+ARG PULUMI_VERSION
 RUN microdnf install -y \
     curl \
     make \
@@ -11,11 +11,8 @@ RUN microdnf install -y \
     tar \
     gcc-c++
 # Install the Pulumi SDK, including the CLI and language runtimes.
-RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-    curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION ; \
-    fi
+RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
+
 # The runtime container
 FROM redhat/ubi8-minimal:latest
 WORKDIR /pulumi/projects


### PR DESCRIPTION
Makes PULUMI_VERSION a required argument for all Docker images.  Removes
a default value of "latest" and simplifies the `curl` command to install
Pulumi.