### PR TITLE
Add entrypoint command with npm install hook

### DIFF
--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && \
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
+COPY entrypoint.sh /usr/local/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
-CMD ["pulumi"]
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -31,6 +31,7 @@ RUN microdnf install -y \
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
+COPY entrypoint.sh /usr/local/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
-CMD ["pulumi"]
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/docker/nodejs/entrypoint.sh
+++ b/docker/nodejs/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -f package.json ]]; then
+  npm install
+fi
+
+pulumi "$@"


### PR DESCRIPTION
## Context

It's quite common to see users to override the entrypoint with `bash -c 'npm i & pulumi <doSomething>`, so why don't just have that logic baked into the container entrypoint instead?

## Changes

* Add entrypoint.sh
* Install npm modules