### PR TITLE
Upgrade Node.js to version 16 (LTS)

### DIFF
--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update -y && \
   ./aws/install && \
   rm -rf aws && \
   # Add additional apt repos all at once
-  echo "deb https://deb.nodesource.com/node_14.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
+  echo "deb https://deb.nodesource.com/node_16.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main"                                           | tee /etc/apt/sources.list.d/yarn.list             && \
   echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list           && \
   echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main"               | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
This is very useful for our project, and it would be a nice thing to have in the next version of the Pulumi Docker Image.
Thanks