### PR TITLE
Use sdkman to install maven and gradle in UBI images

### DIFF
--- a/docker/java/Dockerfile.ubi
+++ b/docker/java/Dockerfile.ubi
@@ -12,9 +12,6 @@ RUN microdnf install -y \
 # Install the Pulumi SDK, including the CLI and language runtimes.
 RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
-RUN curl https://downloads.gradle-dn.com/distributions/gradle-7.4.2-bin.zip -o gradle.zip \
-    && unzip gradle.zip
-
 # The runtime container
 FROM redhat/ubi8-minimal:latest
 LABEL org.opencontainers.image.description="Pulumi CLI container for Java"
@@ -23,24 +20,30 @@ WORKDIR /pulumi/projects
 RUN microdnf install -y \
     git \
     tar \
-    java-11-openjdk \
+    java-11-openjdk-headless \
     curl \
     unzip \
-    ca-certificates
+    zip \
+    findutils \
+    ca-certificates \
+    && microdnf clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
 
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz -o maven.tar.gz \
-    && tar -xvf maven.tar.gz \
-    && mv apache-maven-3.8.6 /pulumi/ \
-    && rm maven.tar.gz
-
+RUN curl -fsSL "https://get.sdkman.io" | bash \
+    && bash -c ". /root/.sdkman/bin/sdkman-init.sh \
+        && sdk install maven \
+        && sdk install gradle \
+        && sdk flush archives \
+        && sdk flush temp \
+        "
 
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-java* /pulumi/bin/
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
-COPY --from=builder /gradle-7.4.2 /pulumi/
 
-ENV PATH "/pulumi/bin:/pulumi/apache-maven-3.8.6/bin:/pulumi/gradle-7.4.2/bin:${PATH}"
-ENV JAVA_HOME "/usr/lib/jvm/java-11-openjdk-11.0.15.0.10-2.el8_6.x86_64"
+ENV PATH="/pulumi/bin:/root/.sdkman/candidates/maven/current/bin:/root/.sdkman/candidates/gradle/current/bin:${PATH}" \
+    JAVA_HOME="/usr/lib/jvm/java-11" \
+    JAVA_VENDOR="openjdk" \
+    JAVA_VERSION="11"
 
 CMD ["pulumi"]

--- a/docker/java/Dockerfile.ubi
+++ b/docker/java/Dockerfile.ubi
@@ -42,7 +42,7 @@ COPY --from=builder /root/.pulumi/bin/*-java* /pulumi/bin/
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 
 ENV PATH="/pulumi/bin:/root/.sdkman/candidates/maven/current/bin:/root/.sdkman/candidates/gradle/current/bin:${PATH}" \
-    JAVA_HOME="/usr/lib/jvm/java-11" \
+    JAVA_HOME="/usr/lib/jvm/jre-11-openjdk" \
     JAVA_VENDOR="openjdk" \
     JAVA_VERSION="11"
 


### PR DESCRIPTION
This installs Maven >=3.8 and Gradle >=7.4 at present time, which meets our minimum version requirements, and ensures we stay up to date with distributions as they become available.

The upside is that we do not have to manually track Maven or Gradle for updates, including security updates.

There are two obvious downsides:

1. We lose some supply chain integrity here. Is this a blocker? We already were relying on HTTPS downloads for Maven and Gradle, this introduces sdkman as an additional dependency. This is a "trusting trust" issue, I think - we need to rely on a third party or ourselves to track Maven & Gradle releases.

2. We cannot specify a semver or upper bound for Maven or Gradle, so we will automatically opt into new major versions. These are slow moving tools, but nevertheless we may want to be careful about opting in to breaking changes. (These tools may also not use semver.)

Fixes #94 