### PR TITLE
Use Pulumi Base Image instead of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ Tags on each image match the installed version of Pulumi.  The `latest` tag matc
 
 The base and SDK-specific images are considerably smaller than the combined `pulumi/pulumi` container (100 to 150 MB, compared to ~1 GB for the combined image, depending on the base OS).
 
+## Building the Images Locally
+
+To build the images locally, run:
+
+```
+docker build \
+  -f docker/pulumi/Dockerfile \
+  --platform linux/amd64 \
+  --build-arg PULUMI_VERSION=3.39.0 \
+  docker/pulumi
+```
+
+You can change `PULUMI_VERSION` to whichever version you prefer. Only platform `linux/amd64` is supported at this time.
+
 ## Build Matrix
 
 Each of the images described above (except the full `pulumi/pulumi` image) are built on a matrix of the following base images and platforms:

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -1,4 +1,8 @@
-FROM pulumi/pulumi-base:latest
+# Passing --build-arg PULUMI_VERSION=vX.Y.Z will use that version
+# of the SDK. Otherwise, we use whatever get.pulumi.com thinks is
+# the latest
+ARG PULUMI_VERSION
+FROM pulumi/pulumi-base:$PULUMI_VERSION
 
 LABEL "repository"="https://github.com/pulumi/pulumi"
 LABEL "homepage"="https://pulumi.com"
@@ -10,12 +14,11 @@ ENV GOLANG_SHA256 956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc272
 
 # Install deps all in one step
 RUN apt-get update -y && \
+  apt-get upgrade -y && \
   apt-get install -y \
   apt-transport-https \
   build-essential \
-  ca-certificates \
   curl \
-  git \
   gnupg \
   python3 \
   python-is-python3 \
@@ -92,14 +95,5 @@ RUN curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-
   helm repo add stable https://charts.helm.sh/stable && \
   helm repo update
 
-# Passing --build-arg PULUMI_VERSION=vX.Y.Z will use that version
-# of the SDK. Otherwise, we use whatever get.pulumi.com thinks is
-# the latest
-ARG PULUMI_VERSION
-
-# Install the Pulumi SDK, including the CLI and language runtimes.
-RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION && \
-  mv ~/.pulumi/bin/* /usr/bin
-
-# I think it's safe to say if we're using this mega image, we want pulumi
+# It's safe to say if we're using this mega image, we want pulumi
 ENTRYPOINT ["pulumi"]

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 LABEL "repository"="https://github.com/pulumi/pulumi"
 LABEL "homepage"="https://pulumi.com"

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM pulumi/pulumi-base:latest
 
 LABEL "repository"="https://github.com/pulumi/pulumi"
 LABEL "homepage"="https://pulumi.com"
@@ -17,6 +17,8 @@ RUN apt-get update -y && \
   curl \
   git \
   gnupg \
+  python3 \
+  python-is-python3 \
   software-properties-common \
   wget \
   unzip && \


### PR DESCRIPTION
This PR switches the Kitchen Sink image to be `FROM` the Pulumi base image instead of Debian.

As is, I'm not sure this will actually speed up image caching, since the base image doesn't contain much of anything -- it installs Pulumi, but as written, this PR requires the Kitchen Sink to _reinstall_ pulumi using the provided version build-arg. I'm going to see if I can use the build-arg in the `FROM` clause to dynamically specify the base, allowing us to skip the installation steps already conducted by the base.

Closes #114 