### PR TITLE
Bump Node12 to Node14

### DIFF
--- a/docker/nodejs/dnf/nodejs.module
+++ b/docker/nodejs/dnf/nodejs.module
@@ -1,5 +1,5 @@
 [nodejs] 
 name=nodejs 
-stream=12
+stream=14
 profiles= 
 state=enabled


### PR DESCRIPTION
This PR bumps the version of NodeJS to 14, which is the minimum required version used by Pulumi 3.39.1.
This fixes the broken build.

Closes https://github.com/pulumi/pulumi-docker-containers/issues/117