### PR TITLE
feat: Add curl to base and language images

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache \
   apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y \
+  curl \
   git \
   ca-certificates
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -48,6 +48,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache \
     --mount=target=/var/cache/apt,type=cache \
     apt-get update -y && \
     apt-get install -y \
+    curl \
     git \
     ca-certificates; \
     mkdir -p /go

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y && \
         java-common \
         maven \
         gradle \
+        curl \
         git
 
 # Uses the workdir, copies from pulumi interim container

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /pulumi/projects
 # Install needed tools, like git
 RUN apt-get update -y && \
     apt-get install -y \
+    curl \
     git \
     ca-certificates
 

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /pulumi/projects
 # Install needed tools, like git
 RUN apt-get update -y && \
     apt-get install -y \
+    curl \
     git \
     ca-certificates
 


### PR DESCRIPTION
An ask from our friends in the service team to ensure `curl` is present in images used in examples and documentation.

The dotnet Debian image already contained `curl`.

Resolves #119.