### PR TITLE
handle potential cgo dependencies

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/pulumi-language-go /pulumi/bin/pulumi-language-go
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/pulumi-analyzer-policy
 ENV GOPATH=/go
+ENV CGO_ENABLED=0
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/go/Dockerfile.ubi
+++ b/docker/go/Dockerfile.ubi
@@ -51,6 +51,7 @@ COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/pulumi-language-go /pulumi/bin/pulumi-language-go
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/pulumi-analyzer-policy
 ENV GOPATH=/go
+ENV CGO_ENABLED=0
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]


### PR DESCRIPTION
Adds gcc to the Go docker images to handle potential pulumi or pulumi test cgo dependencies that are breaking builds.

Part of #127

I'm still seeing issues with Go builds being broken.
https://github.com/pulumi/pulumi-docker-containers/actions/runs/4319115397

Might as well add gcc to make these containers less fragile in the future.

Thoughts?