### PR TITLE
Use python:3.9-slim-bullseye

### DIFF
--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim AS base
+# TODO[pulumi/pulumi-docker-containers#147]: Move back to using `python:3.9-slim`
+# as the base image when upstream issues with Debian "bookworm" are resolved.
+# For now, we continue using Debian "bullseye" as the base image.
+FROM python:3.9-slim-bullseye AS base
 
 LABEL "repository"="https://github.com/pulumi/pulumi"
 LABEL "homepage"="https://pulumi.com"


### PR DESCRIPTION
Debian "bookworm" was released on June 10, and there are some issues installing the Azure CLI and Java on bookworm. This commit changes us to go back to using Debian "bullseye" for now.

Fixes #143