### PR TITLE
Bump NodeJS in base image to 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.80.0
+
+- Upgrade NodeJS in the Pulumi base image to 18 ([#150](https://github.com/pulumi/pulumi-docker-containers/pull/150))
+
 ## 3.63.0
 
 - Upgrade Go to 1.20.3. ([#134](https://github.com/pulumi/pulumi-docker-containers/pull/134))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## 3.80.0
+## 3.82.0
 
-- Upgrade NodeJS in the Pulumi base image to 18 ([#150](https://github.com/pulumi/pulumi-docker-containers/pull/150))
+- Upgrade Node.js in the `pulumi/pulumi` image and `pulumi/nodejs` UBI image to the Active LTS version 18
+  ([#150](https://github.com/pulumi/pulumi-docker-containers/pull/150))
 
 ## 3.63.0
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ Images are pushed to:
 - .NET 6.0
 - Go 1.20
 - JDK 11
-- Node.js 16
+- Node.js 18
 - Python 3.9
+
+### NodeJS LTS
+
+Our Docker images aim to use NodeJS LTS version (v18 as of writing). You can pin the image tag to a particular version in order to avoid unintended upgrades.
 
 ## Scanning
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Images are pushed to:
 - Node.js 18
 - Python 3.9
 
-### NodeJS LTS
+### Version Policy
 
-Our Docker images aim to use NodeJS LTS version (v18 as of writing). You can pin the image tag to a particular version in order to avoid unintended upgrades.
+Language runtimes are kept up-to-date with current LTS versions. You can pin the image tag to a particular version in order to avoid unintended upgrades.
 
 ## Scanning
 
@@ -62,6 +62,6 @@ The base and SDK images _do not_ include additional tools you might want to use 
 
 ## Release Cadence
 
-The images in this repository are released automatically as part of the release process for the `pulumi` CLI. You can expect **new minor releases** roughly every other week, with patch releases more frequently as necessary.
+The images in this repository are released automatically as part of the release process for the `pulumi` CLI. You can expect **new minor releases** roughly every week, with patch releases more frequently as necessary.
 
 The image tags for each image in this repository mirror the git tags on the `pulumi` CLI. Thus, when [`pulumi v3.35.1`](https://github.com/pulumi/pulumi/releases) is released, you will find a corresponding Docker image [`pulumi/pulumi:3.35.1`](https://hub.docker.com/r/pulumi/pulumi) in DockerHub, ECR, and GHCR.

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 
 # The runtime container
-FROM node:lts-bullseye-slim
+FROM node:18-bullseye-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for nodejs"
 WORKDIR /pulumi/projects
 

--- a/docker/nodejs/dnf/nodejs.module
+++ b/docker/nodejs/dnf/nodejs.module
@@ -1,5 +1,5 @@
 [nodejs] 
 name=nodejs 
-stream=14
+stream=18
 profiles= 
 state=enabled

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update -y && \
   rm -rf aws && \
   rm awscliv2.zip && \
   # Add additional apt repos all at once
-  echo "deb https://deb.nodesource.com/node_16.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
+  echo "deb https://deb.nodesource.com/node_18.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main"                                           | tee /etc/apt/sources.list.d/yarn.list             && \
   echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list           && \
   echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main"               | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
This PR upgrades Node.js in the `pulumi/pulumi` image and `pulumi/nodejs` UBI image to the Active LTS version 18, and documents our version policy to keep language runtimes up-to-date with LTS versions.

Fixes #148 