### PR TITLE
Bump NodeJS in base image to LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.80.0
+
+- Upgrade NodeJS in the Pulumi base image to 18 ([#150](https://github.com/pulumi/pulumi-docker-containers/pull/150))
+
 ## 3.63.0
 
 - Upgrade Go to 1.20.3. ([#134](https://github.com/pulumi/pulumi-docker-containers/pull/134))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Images are pushed to:
 - .NET 6.0
 - Go 1.20
 - JDK 11
-- Node.js 16
+- Node.js 18
 - Python 3.9
 
 ## Scanning

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update -y && \
   rm -rf aws && \
   rm awscliv2.zip && \
   # Add additional apt repos all at once
-  echo "deb https://deb.nodesource.com/node_16.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
+  echo "deb https://deb.nodesource.com/node_lts.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main"                                           | tee /etc/apt/sources.list.d/yarn.list             && \
   echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list           && \
   echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main"               | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
This PR bumps NodeJS in the base pulumi image to `LTS`

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/148