### PR TITLE
Publish images for different python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,14 @@ jobs:
       matrix:
         sdk: ["nodejs", "python", "dotnet", "go", "java"]
         arch: ["amd64", "arm64"]
+        include:
+          - python_version: ""
+          - sdk: python
+            python_version: "3.9"
+          - sdk: python
+            python_verison: "3.10"
+          - sdk: python
+            python_version: "3.11"
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
@@ -197,6 +205,10 @@ jobs:
         if: ${{ !env.PULUMI_VERSION }}
         run: |
           echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV
+      - name: Set arguments for python versions
+        run: |
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -211,8 +223,9 @@ jobs:
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.debian \
             --platform linux/${{ matrix.arch }} \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{env.PYTHON_DOCKER_TAG}}-debian-${{ matrix.arch }} \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
+            ${{ env.PYTHON_BUILD_ARG }} \
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
@@ -244,7 +257,7 @@ jobs:
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             --platform ${{ matrix.arch }} \
-            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{env.PYTHON_DOCKER_TAG}}-debian-${{ matrix.arch }} \
             -c "/src/pulumi-test-containers -test.parallel=1 -test.timeout=1h -test.v -test.run TestPulumiDockerImage"
   ubi-sdk:
     name: UBI SDK images
@@ -253,6 +266,15 @@ jobs:
       fail-fast: false
       matrix:
         sdk: ["nodejs", "python", "dotnet", "go", "java"]
+        # If building for the python SDK, we also want to build for several python versions
+        include:
+          - python_version: ""
+          - sdk: python
+            python_version: "3.9"
+          - sdk: python
+            python_verison: "3.10"
+          - sdk: python
+            python_version: "3.11"
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
@@ -260,6 +282,10 @@ jobs:
         if: ${{ !env.PULUMI_VERSION }}
         run: |
           echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV
+      - name: Set arguments for python versions
+        run: |
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -278,8 +304,9 @@ jobs:
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.ubi \
             --platform linux/amd64 \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{env.PYTHON_DOCKER_TAG}}-ubi \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
+            ${{ env.PYTHON_BUILD_ARG }} \
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
@@ -310,5 +337,5 @@ jobs:
             -e PULUMI_ORG=${PULUMI_ORG} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
-            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{env.PYTHON_DOCKER_TAG}}-ubi \
             -c "/src/pulumi-test-containers -test.parallel=1 -test.timeout=1h -test.v -test.run TestPulumiDockerImage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,8 @@ jobs:
           echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV
       - name: Set arguments for python versions
         run: |
-          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
-          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${{matrix.python_version}}" || "" }}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -284,8 +284,8 @@ jobs:
           echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV
       - name: Set arguments for python versions
         run: |
-          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
-          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,18 @@ jobs:
       matrix:
         sdk: ["nodejs", "python", "dotnet", "go", "java"]
         arch: ["amd64", "arm64"]
+        include:
+          - sdk: python
+            python_version: "3.9"
+          - sdk: python
+            python_verison: "3.10"
+          - sdk: python
+            python_version: "3.11"
     steps:
+      - name: Set arguments for python versions
+        run: |
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -256,8 +267,9 @@ jobs:
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.debian \
             --platform linux/${{ matrix.arch }} \
-            -t ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            -t ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-${{ matrix.arch }} \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
+            ${{ env.PYTHON_BUILD_ARG }}
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
@@ -289,11 +301,11 @@ jobs:
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             --platform ${{ matrix.arch }} \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-${{ matrix.arch }} \
             -c "/src/pulumi-test-containers -test.parallel=1 -test.timeout=1h -test.v -test.run TestPulumiDockerImage"
       - name: Push image
         run: |
-          docker push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}
+          docker push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-${{ matrix.arch }}
   debian-sdk-manifests:
     name: Debian SDK manifests
     needs: ["debian-sdk"]
@@ -302,7 +314,18 @@ jobs:
       fail-fast: false
       matrix:
         sdk: ["nodejs", "python", "dotnet", "go", "java"]
+        include:
+          - python_version: ""
+          - sdk: python
+            python_version: "3.9"
+          - sdk: python
+            python_verison: "3.10"
+          - sdk: python
+            python_version: "3.11"
     steps:
+      - name: Set arguments for python versions
+        run: |
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -311,21 +334,21 @@ jobs:
       - name: Debian manifest
         run: |
           docker manifest create \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-amd64
-          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-amd64
+          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian
       - name: Suffix-less manifest
         run: |
           docker manifest create \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }} \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-amd64
-          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }} \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-debian-amd64
+          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}
       - name: Suffix-less manifest (latest)
         # Manifest lists can't be a source for `docker tag`, so we create an
         # additional copy of the previous manifest to tag latest:
-        if: ${{ github.event.inputs.tag_latest || github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event.inputs.tag_latest || github.event_name == 'repository_dispatch' }} && ${{ env.PYTHON_DOCKER_TAG == "" }}}
         run: |
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:latest \
@@ -340,7 +363,19 @@ jobs:
       fail-fast: false
       matrix:
         sdk: ["nodejs", "python", "dotnet", "go", "java"]
+        include:
+          - python_version: ""
+          - sdk: python
+            python_version: "3.9"
+          - sdk: python
+            python_verison: "3.10"
+          - sdk: python
+            python_version: "3.11"
     steps:
+      - name: Set arguments for python versions
+        run: |
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -363,8 +398,9 @@ jobs:
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.ubi \
             --platform linux/amd64 \
-            -t ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            -t ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-ubi \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
+            ${{ env.PYTHON_BUILD_ARG }} \
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
@@ -395,11 +431,11 @@ jobs:
             -e PULUMI_ORG=${PULUMI_ORG} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-ubi \
             -c "/src/pulumi-test-containers -test.parallel=1 -test.timeout=1h -test.v -test.run TestPulumiDockerImage"
       - name: Push image
         run: |
-          docker push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi
+          docker push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}${{ env.PYTHON_DOCKER_TAG }}-ubi
 
   start-syncs:
     name: Start syncs to other container registries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,8 +246,8 @@ jobs:
     steps:
       - name: Set arguments for python versions
         run: |
-          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
-          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -325,7 +325,7 @@ jobs:
     steps:
       - name: Set arguments for python versions
         run: |
-          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -374,8 +374,8 @@ jobs:
     steps:
       - name: Set arguments for python versions
         run: |
-          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || ""}}' >> $GITHUB_ENV
-          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${matrix.python_version}" || ""}}' >> $GITHUB_ENV
+          echo "PYTHON_BUILD_ARG='${{ matrix.python_version != "" && "--build-arg PYTHON_VERSION=${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
+          echo "PYTHON_DOCKER_TAG='${{ matrix.python_version != "" && "-python-${{ matrix.python_version }}" || "" }}' >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.86.0
+
+- Add images for python sdk based on python versions 3.9, 3.10, and 3.11
+
 ## 3.82.0
 
 - Upgrade Node.js in the `pulumi/pulumi` image and `pulumi/nodejs` UBI image to the Active LTS version 18


### PR DESCRIPTION
This is an attempt to publish docker images with different python versions.

This should push an image tagged with `python-3.9`, `python-3.10` and `python-3.11` when building each python version. It should also keep a base version with no arguments, which will default to what is specified in the docker image.

This is my first contribution here, so I welcome any feedback!

fixes: https://github.com/pulumi/pulumi-docker-containers/issues/144