### PR TITLE
set dotnet install dir to /usr/share/dotnet

### DIFF
--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -77,9 +77,9 @@ RUN apt-get update -y && \
 
 # Install dotnet 6.0 using instructions from:
 # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -channel 6.0
-ENV PATH "/home/pulumi-kubernetes-operator/.dotnet:/pulumi/bin:${PATH}"
-ENV DOTNET_ROOT /home/pulumi-kubernetes-operator/.dotnet
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -channel 6.0 -InstallDir /usr/share/dotnet
+ENV PATH "/usr/share/dotnet:/pulumi/bin:${PATH}"
+ENV DOTNET_ROOT /usr/share/dotnet
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 # Allow newer dotnet version (e.g. 6) to build projects targeting older frameworks (v3.1)
 ENV DOTNET_ROLL_FORWARD Major

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -78,8 +78,8 @@ RUN apt-get update -y && \
 # Install dotnet 6.0 using instructions from:
 # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -channel 6.0
-ENV PATH "/root/.dotnet:/pulumi/bin:${PATH}"
-ENV DOTNET_ROOT /root/.dotnet
+ENV PATH "/home/pulumi-kubernetes-operator/.dotnet:/pulumi/bin:${PATH}"
+ENV DOTNET_ROOT /home/pulumi-kubernetes-operator/.dotnet
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 # Allow newer dotnet version (e.g. 6) to build projects targeting older frameworks (v3.1)
 ENV DOTNET_ROLL_FORWARD Major


### PR DESCRIPTION
Instead of /root/.dotnet
Addresses the issue #113: .NET installed under /root/.dotnet is inaccessible when run as non-root
