### PR TITLE
Fix GHCR sync token

### DIFF
--- a/.github/workflows/sync-ghcr.yml
+++ b/.github/workflows/sync-ghcr.yml
@@ -33,8 +33,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: pulumibot
-          password: ${{ secrets.PULUMI_BOT_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag ${{ env.PULUMI_VERSION }} and push to GHCR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}
@@ -75,8 +75,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: pulumibot
-          password: ${{ secrets.PULUMI_BOT_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag ${{ env.PULUMI_VERSION }}-debian-amd64 image and push to GHCR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}-debian-amd64
@@ -130,8 +130,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: pulumibot
-          password: ${{ secrets.PULUMI_BOT_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag ${{ env.PULUMI_VERSION }}-ubi image and push to GHCR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}-ubi


### PR DESCRIPTION
Refs https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/

GHCR is compatible with the default `GITHUB_TOKEN` and doesn't need to use pulumi-bot's PAT.

I've given the pulumi-docker-containers repo write access on the pulumi-nodejs, pulumi-go, pulumi-base, pulumi-dotnet, pulumi-python, and pulumi images.

Fixes #167