### PR TITLE
add oracle cloud cli to image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.87.1
+
+- Added oracle cloud infrastructure cli (oci-cli)
+
 ## 3.87.0
 
 - Upgrade Go to 1.21.1. ([#159](https://github.com/pulumi/pulumi-docker-containers/pull/159))

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -59,9 +59,11 @@ RUN apt-get update -y && \
   kubectl \
   nodejs \
   yarn && \
-  pip3 install oci-cli && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
+
+# Install Oracle Cloud Infrastructure CLI
+RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- --exec-dir /usr/bin --accept-all-defaults
 
 # Install Go
 RUN curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update -y && \
   kubectl \
   nodejs \
   yarn && \
+  pip3 install oci-cli && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is a straightforward contribution that I need for my own stuff.
Using Oracle Cloud Kubernetes engine with pulumi requires one of the following:

1. A static access token using a service account (not ideal)
2. One IAM user for the ci/cd process with permissions to authenticate in the cluster.

The second option connects with Kubernetes using short-lived tokens emitted by the oci-cli executable. The executable will use a config file and a pem file in the ~/.oci folder (but can be configured in other ways if needed); then we can configure ~/.kube/config to use the CLI to emit the tokens.

I need this CLI installed to use in the Pulumi cloud deployments feature with native OCI authentication, as explained in the second option.

It's better to have this upstream, but I can also maintain a custom image build from the main image.

Thanks.

