### PR TITLE
Migrate to the k8s community-owned repository

### DIFF
--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -43,7 +43,10 @@ RUN apt-get update -y && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main"                                           | tee /etc/apt/sources.list.d/yarn.list             && \
   echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list           && \
   echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main"               | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  echo "deb http://apt.kubernetes.io/ kubernetes-xenial main"                                     | tee /etc/apt/sources.list.d/kubernetes.list       && \
+  KUBE_LATEST=$(curl -L -s https://dl.k8s.io/release/stable.txt | awk 'BEGIN { FS="." } { printf "%s.%s", $1, $2 }') && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list && \
   echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure.list            && \
   # Install second wave of dependencies
   apt-get update -y && \


### PR DESCRIPTION
The legacy Google-hosted package repositories have gone away. See https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/

When building the image, we now get the following error:

```
The repository 'http://apt.kubernetes.io kubernetes-xenial Release' does not have a Release file
```

This change migrates to the community-owned repository.

Fixes #184