### PR TITLE
Upgrade Node.js to Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Images are pushed to:
 - .NET 6.0
 - Go 1.21
 - JDK 11
-- Node.js 18
+- Node.js 20
 - Python 3.9
 
 ### Version Policy

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 
 # The runtime container
-FROM node:18-bullseye-slim
+FROM node:20-bullseye-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for nodejs"
 WORKDIR /pulumi/projects
 

--- a/docker/nodejs/dnf/nodejs.module
+++ b/docker/nodejs/dnf/nodejs.module
@@ -1,5 +1,5 @@
 [nodejs] 
 name=nodejs 
-stream=18
+stream=20
 profiles= 
 state=enabled

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update -y && \
   rm -rf aws && \
   rm awscliv2.zip && \
   # Add additional apt repos all at once
-  echo "deb https://deb.nodesource.com/node_18.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
+  echo "deb https://deb.nodesource.com/node_20.x $(lsb_release -cs) main"                         | tee /etc/apt/sources.list.d/node.list             && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main"                                           | tee /etc/apt/sources.list.d/yarn.list             && \
   echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list           && \
   echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main"               | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
Node 20 has been the Active LTS version since 2023-10-24.

Fixes #158