### PR TITLE
Install the latest version of npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.112.0
+
+- Install the latest version of `npm` in the `pulumi/nodejs` image
+  ([#190](https://github.com/pulumi/pulumi-docker-containers/pull/190))
+
 ## 3.87.0
 
 - Upgrade Go to 1.21.1. ([#159](https://github.com/pulumi/pulumi-docker-containers/pull/159))

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update -y && \
     apt-get install -y \
     curl \
     git \
-    ca-certificates
+    ca-certificates && \
+    npm install -g npm@10.5.1
 
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -25,6 +25,7 @@ RUN microdnf install -y \
     tar \
     nodejs \
     ca-certificates && \
+    npm install -g npm@10.5.1 && \
     npm install -g yarn
 
 # Uses the workdir, copies from pulumi interim container


### PR DESCRIPTION
We're currently running into an issue installing dependencies with `npm` from the Debian Arm64 image, which is blocking releasing v3.112.0 of the images. Installing the latest version of `npm` addresses the problem.

Once this is merged, I'm going to re-kick off the release workflow for these images for v3.112.0.

Fixes #187