### PR TITLE
Revert "add oracle cloud cli to image (#182)"

### DIFF
--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -62,9 +62,6 @@ RUN apt-get update -y && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
 
-# Install Oracle Cloud Infrastructure CLI
-RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- --exec-dir /usr/bin --accept-all-defaults
-
 # Install Go
 RUN curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
   echo "${GOLANG_SHA256} /tmp/go.tgz" | sha256sum -c - && \


### PR DESCRIPTION
This reverts commit ddce0619045e91d9498f24dd5d870d8f7b05a9d5.

Installing the Oracle CLI the way we're installing it is causing `/root/.bashrc` to be modified to include `/usr/bin` (the location where the `oci` binary is placed) at the front of `PATH`, _before_ `/usr/local/bin`.

This ends up breaking `python3 -m venv venv` called from Pulumi Deployments because it ends up using the system Python at `/usr/bin/python3` rather than the version of Python from this image that should be used at `/usr/local/bin/python3` (due to the `PATH` change in `.bashrc`), and the system Python does not have `venv` available.

It may be possible to address this by installing the Oracle CLI binary in `/usr/local/bin` rather than `/usr/bin`, but I'd like to see if it's possible to install the Oracle CLI without updating `.bashrc` at all, so reverting this in the meantime.

Fixes #193