### PR TITLE
Fix compilation issue when running azure-java in the UBI pulumi-java image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix compilation issue when running `azure-java` in `pulumi-java`
+  ([#212](https://github.com/pulumi/pulumi-docker-containers/pull/212))
+
 - Test Azure CLI and templates in the `pulumi/pulumi` image
   ([#208](https://github.com/pulumi/pulumi-docker-containers/pull/208))
 

--- a/docker/java/Dockerfile.ubi
+++ b/docker/java/Dockerfile.ubi
@@ -20,7 +20,7 @@ WORKDIR /pulumi/projects
 RUN microdnf install -y \
     git \
     tar \
-    java-11-openjdk-headless \
+    java-11-openjdk-devel \
     curl \
     unzip \
     zip \

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -62,11 +62,6 @@ func TestPulumiTemplateTests(t *testing.T) {
 	for _, sdk := range sdksToTest {
 		// python, typescript, ...
 		testCases = append(testCases, testCase{sdk, map[string]string{}})
-		if sdk == "java" {
-			// Don't add cloud-specific tests for Java.
-			// TODO: https://github.com/pulumi/pulumi-docker-containers/issues/210
-			continue
-		}
 		for _, cloud := range clouds {
 			// azure-python, aws-python, ...
 			if sdk == "typescript" && cloud == "azure" {


### PR DESCRIPTION
We need to install `java-11-openjdk-devel`, not `java-11-openjdk-headless` to have a full Java dev environment.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/210