### PR TITLE
Test AWS CLI and templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ env:
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+  AWS_REGION: "us-west-2"
 
 jobs:
   comment-notification:
@@ -97,6 +98,15 @@ jobs:
         working-directory: tests
         run: |
           GOOS=linux GOARCH=amd64 go test -c -o /tmp/pulumi-test-containers ./...
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 14400 # 4 hours
+          role-session-name: pulumi-docker-containers@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Run Pulumi Template Tests
         run: |
           docker run \
@@ -107,6 +117,10 @@ jobs:
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
             -e ARM_TENANT_ID=${ARM_TENANT_ID} \
             -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
+            -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+            -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+            -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+            -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             ${{ env.DOCKER_USERNAME }}/pulumi:${{ env.PULUMI_VERSION }} \
@@ -122,6 +136,10 @@ jobs:
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
             -e ARM_TENANT_ID=${ARM_TENANT_ID} \
             -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
+            -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+            -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+            -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+            -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             ${{ env.DOCKER_USERNAME }}/pulumi:${{ env.PULUMI_VERSION }} \
@@ -167,6 +185,15 @@ jobs:
         working-directory: tests
         run: |
           GOOS=linux GOARCH=amd64 go test -c -o /tmp/pulumi-test-containers ./...
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 14400 # 4 hours
+          role-session-name: pulumi-docker-containers@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Run Pulumi Template Tests
         run: |
           docker run \
@@ -177,6 +204,10 @@ jobs:
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
             -e ARM_TENANT_ID=${ARM_TENANT_ID} \
             -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
+            -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+            -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+            -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+            -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             ${{ env.DOCKER_USERNAME }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }} \
@@ -252,7 +283,6 @@ jobs:
         working-directory: tests
         run: |
           GOOS=linux GOARCH=${{ matrix.arch }} go test -c -o /tmp/pulumi-test-containers ./...
-
       - name: Set SDKS_TO_TEST (dotnet)
         if: ${{ matrix.sdk == 'dotnet' }}
         run: echo "SDKS_TO_TEST=csharp" >> $GITHUB_ENV
@@ -262,7 +292,15 @@ jobs:
       - name: Set SDKS_TO_TEST (default)
         if: ${{ matrix.sdk != 'dotnet' && matrix.sdk != 'nodejs' }}
         run: echo "SDKS_TO_TEST=${{ matrix.sdk}}" >> $GITHUB_ENV
-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 14400 # 4 hours
+          role-session-name: pulumi-docker-containers@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Run Pulumi Template Tests
         run: |
           docker run \
@@ -274,6 +312,10 @@ jobs:
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
             -e ARM_TENANT_ID=${ARM_TENANT_ID} \
             -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
+            -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+            -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+            -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+            -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             --platform ${{ matrix.arch }} \
@@ -324,7 +366,6 @@ jobs:
         working-directory: tests
         run: |
           GOOS=linux GOARCH=amd64 go test -c -o /tmp/pulumi-test-containers ./...
-
       - name: Set SDKS_TO_TEST (dotnet)
         if: ${{ matrix.sdk == 'dotnet' }}
         run: echo "SDKS_TO_TEST=csharp" >> $GITHUB_ENV
@@ -334,7 +375,15 @@ jobs:
       - name: Set SDKS_TO_TEST (default)
         if: ${{ matrix.sdk != 'dotnet' && matrix.sdk != 'nodejs' }}
         run: echo "SDKS_TO_TEST=${{ matrix.sdk}}" >> $GITHUB_ENV
-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 14400 # 4 hours
+          role-session-name: pulumi-docker-containers@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Run Pulumi Template Tests
         run: |
           docker run \
@@ -346,6 +395,10 @@ jobs:
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
             -e ARM_TENANT_ID=${ARM_TENANT_ID} \
             -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
+            -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+            -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+            -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+            -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /bin/bash \
             ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+
+- Test AWS CLI and templates in the `pulumi/pulumi` image
+  ([#213](https://github.com/pulumi/pulumi-docker-containers/pull/213))
+
 - Fix compilation issue when running `azure-java` in `pulumi-java`
   ([#212](https://github.com/pulumi/pulumi-docker-containers/pull/212))
 


### PR DESCRIPTION
Test that the aws CLI is working and can login.

Test that the aws-${sdk} templates work.

This requires the following secrets in GHA:
 * AWS_ACCESS_KEY_ID
 * AWS_SECRET_ACCESS_KEY
 * AWS_CI_ROLE_ARN

Stacked on https://github.com/pulumi/pulumi-docker-containers/pull/212

Ref https://github.com/pulumi/pulumi-docker-containers/issues/209

