### PR TITLE
Unpin Azure CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Unpin Azure CLI tools ([#214])(https://github.com/pulumi/pulumi-docker-containers/pull/214)
+
 - Ensure that the containers are compatible with deployments
   ([#219])(https://github.com/pulumi/pulumi-docker-containers/pull/219)
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -51,8 +51,7 @@ RUN apt-get update -y && \
   # Install second wave of dependencies
   apt-get update -y && \
   apt-get install -y \
-  # Pin azure-cli to 2.33.1 as workaround for https://github.com/pulumi/pulumi-docker-containers/issues/106
-  "azure-cli=2.33.1-1~bullseye" \
+  azure-cli \
   docker-ce \
   google-cloud-sdk \
   google-cloud-sdk-gke-gcloud-auth-plugin \


### PR DESCRIPTION
We had previously pinned `az` to version 2.33.1 to work around an issue with a deprecation warning. The underlying issue in the Azure SDK has since been fixed in https://github.com/pulumi/pulumi-azure-native/issues/1566

Note: we have tests that check that the `az` works (= can login and get account info)