### PR TITLE
Matrix Python debian images

### DIFF
--- a/.github/scripts/gen-matrix.py
+++ b/.github/scripts/gen-matrix.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# This script is used to create the matrix for the language specific images, for example in the `debian-sdk` job. The
+# created matrix has no variables, instead we list each desired combination explicitly in the `include` field.
+# https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-adding-configurations
+#
+# matrix = {
+#     "include": [
+#         {"sdk": "go",     "arch": "amd64", "language_version": "1.21.1", "default": True},
+#         {"sdk": "go",     "arch": "arm64", "language_version": "1.21.1", "default": True},
+#         {"sdk": "python", "arch": "amd64", "language_version": "3.9",    "default": True,  "suffix": "-3.9"},
+#         {"sdk": "python", "arch": "arm64", "language_version": "3.9",    "default": True,  "suffix": "-3.9"},
+#         {"sdk": "python", "arch": "amd64", "language_version": "3.10",   "default": False, "suffix": "-3.10"},
+#         {"sdk": "python", "arch": "arm64", "language_version": "3.10",   "default": False, "suffix": "-3.10"},
+#         ...
+#     ]
+# }
+#
+#  * `language_version` is the version of the language runtime to use, for example `3.9` for Python.
+#  * `suffix` is an optional suffix to append to the image name, for example `-3.9` to generate `pulumi-python-3.9`.
+#  * `default` indicates that this is the default language_version. We will push two tags for the image, once
+#     with and once without the suffix in the name, for example `pulumi-python-3.9` and `pulumi-python`.
+#
+# When running this script, pass `--no-arch` to exclude the `arch` field from the matrix. This is used in the release
+# job for creating the docker manifests. For example the manifest for `pulumi-python:3.123.0-debian` includes the
+# images `pulumi-python-3.123.0-debian-amd64` and `pulumi-python-3.123.0-debian-arm64`, so we don't need to iterate
+# over the architecutres in the matrix.
+#
+import json
+import sys
+
+INCLUDE_ARCH = False if len(sys.argv) > 1 and sys.argv[1] == "--no-arch" else True
+
+archs = ["amd64", "arm64"] if INCLUDE_ARCH else [None]
+matrix = {"include": []}
+
+# SDKs without version suffixes
+sdks = {
+    "nodejs": "18",
+    "go": "1.21.1",
+    "dotnet": "6.0",
+    "java": "not-used-yet",
+}
+# Python versions
+python_default_version = "3.9"
+python_additional_versions = ["3.10", "3.11", "3.12"]
+
+
+def make_entry(*, sdk, arch, default, language_version, suffix=None):
+    entry = {
+        "sdk": sdk,
+        "default": default,
+        "language_version": language_version,
+    }
+    if arch is not None:
+        entry["arch"] = arch
+    if suffix is not None:
+        entry["suffix"] = suffix
+    return entry
+
+
+for arch in archs:
+
+    for sdk, version in sdks.items():
+        matrix["include"].append(
+            make_entry(sdk=sdk, arch=arch, default=True, language_version=version)
+        )
+
+    # Default Python version
+    matrix["include"].append(
+        make_entry(
+            sdk="python",
+            arch=arch,
+            language_version=python_default_version,
+            default=True,
+            suffix=f"-{python_default_version}",
+        )
+    )
+    # Additional Python versions
+    for version in python_additional_versions:
+        matrix["include"].append(
+            make_entry(
+                sdk="python",
+                arch=arch,
+                language_version=version,
+                default=False,
+                suffix=f"-{version}",
+            )
+        )
+
+print(json.dumps(matrix))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,7 @@ env:
   # The organization in the Pulumi SaaS service against which the integration
   # tests will run:
   PULUMI_ORG: "pulumi-test"
-  # We parameterize the Docker Hub username to allow forks to easily test
-  # changes on a separate repo without having to change the username in multiple
-  # places:
-  DOCKER_USERNAME: pulumi
+  DOCKER_ORG: pulumi
   PULUMI_VERSION: ${{ github.event.inputs.pulumi_version || github.event.client_payload.ref }}
   # Do not depend on C library for the tests.
   CGO_ENABLED: "0"
@@ -84,7 +81,7 @@ jobs:
           docker build \
             -f docker/pulumi/Dockerfile \
             --platform linux/amd64 \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi:${{ env.PULUMI_VERSION }} \
+            -t ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }} \
             --target base \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
             --load \
@@ -126,7 +123,7 @@ jobs:
             -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /src/pulumi-test-containers \
-            ${{ env.DOCKER_USERNAME }}/pulumi:${{ env.PULUMI_VERSION }} \
+            ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }} \
             -test.parallel=1 -test.timeout=1h -test.v
 
   provider-build-environment:
@@ -156,7 +153,7 @@ jobs:
           docker build \
             -f docker/pulumi/Dockerfile \
             --platform linux/amd64 \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }} \
+            -t ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }} \
             --target build-environment \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
             --load \
@@ -196,7 +193,7 @@ jobs:
             -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /src/pulumi-test-containers \
-            ${{ env.DOCKER_USERNAME }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }} \
+            ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }} \
             -test.parallel=1 -test.timeout=1h -test.v
 
   base:
@@ -226,16 +223,26 @@ jobs:
             -f docker/base/Dockerfile.${{ matrix.os }} \
             --platform linux/arm64,linux/amd64 \
             . \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi-base:${{ env.PULUMI_VERSION }}-${{ matrix.os }} \
+            -t ${{ env.DOCKER_ORG }}/pulumi-base:${{ env.PULUMI_VERSION }}-${{ matrix.os }} \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }}
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.define-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@master
+      - name: Define Matrix
+        id: define-matrix
+        run: |
+          echo matrix=$(python ./.github/scripts/gen-matrix.py) >> "$GITHUB_OUTPUT"
+
   debian-sdk:
     name: Debian SDK images
     runs-on: ubuntu-latest
+    needs: define-matrix
     strategy:
       fail-fast: false
-      matrix:
-        sdk: ["nodejs", "python", "dotnet", "go", "java"]
-        arch: ["amd64", "arm64"]
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
@@ -243,6 +250,9 @@ jobs:
         if: ${{ !env.PULUMI_VERSION }}
         run: |
           echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV
+      - name: Set image name
+        run: |
+          echo "IMAGE_NAME=${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}" >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -251,14 +261,13 @@ jobs:
         with:
           install: true
       - name: Build
-        # We supply a working directory to the command below due to the
-        # dnf/nodej2.module file that has to mounted into the container.
         run: |
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.debian \
             --platform linux/${{ matrix.arch }} \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            -t ${{ env.IMAGE_NAME }} \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
+            --build-arg LANGUAGE_VERSION=${{ matrix.language_version }} \
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
@@ -307,7 +316,7 @@ jobs:
             --volume /tmp:/src \
             --entrypoint /src/pulumi-test-containers \
             --platform ${{ matrix.arch }} \
-            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            ${{ env.IMAGE_NAME }} \
             -test.parallel=1 -test.timeout=1h -test.v -test.run "TestPulumiTemplateTests|TestEnvironment"
 
   ubi-sdk:
@@ -342,7 +351,7 @@ jobs:
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.ubi \
             --platform linux/amd64 \
-            -t ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            -t ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
             docker/${{ matrix.sdk }} \
             --load
@@ -391,5 +400,5 @@ jobs:
             -e AWS_REGION=${AWS_REGION} \
             --volume /tmp:/src \
             --entrypoint /src/pulumi-test-containers \
-            ${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi \
             -test.parallel=1 -test.timeout=1h -test.v -test.run "TestPulumiTemplateTests|TestEnvironment"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,16 +272,35 @@ jobs:
             ${{ env.DOCKER_ORG }}/pulumi-base:${{ env.PULUMI_VERSION }}-debian-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi-base:${{ env.PULUMI_VERSION }}-debian-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi-base:latest
+
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.define-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@master
+      - name: Define Matrix
+        id: define-matrix
+        run: |
+          echo matrix=$(python ./.github/scripts/gen-matrix.py) >> "$GITHUB_OUTPUT"
+
   debian-sdk:
     name: Debian SDK images
+    needs: define-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sdk: ["nodejs", "python", "dotnet", "go", "java"]
-        arch: ["amd64", "arm64"]
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@master
+      - name: Set image name
+        run: |
+          echo "IMAGE_NAME=${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}" >> $GITHUB_ENV
+      - name: Set default language version image name
+        # For the default language version, we also set a default image name that doesn't include the version suffix
+        if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
+        run: |
+          echo "DEFAULT_IMAGE_NAME=${{ env.DOCKER_USERNAME }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}" >> $GITHUB_ENV
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -294,14 +313,13 @@ jobs:
         with:
           install: true
       - name: Build
-        # We supply a working directory to the command below due to the
-        # dnf/nodej2.module file that has to mounted into the container.
         run: |
           docker build \
             -f docker/${{ matrix.sdk }}/Dockerfile.debian \
             --platform linux/${{ matrix.arch }} \
-            -t ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            -t ${{ env.IMAGE_NAME }} \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
+            --build-arg LANGUAGE_VERSION=${{ matrix.language_version }} \
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
@@ -313,7 +331,6 @@ jobs:
         working-directory: tests
         run: |
           GOOS=linux GOARCH=${{ matrix.arch }} go test -c -o /tmp/pulumi-test-containers ./...
-
       - name: Set SDKS_TO_TEST (dotnet)
         if: ${{ matrix.sdk == 'dotnet' }}
         run: echo "SDKS_TO_TEST=csharp" >> $GITHUB_ENV
@@ -351,19 +368,35 @@ jobs:
             --volume /tmp:/src \
             --entrypoint /src/pulumi-test-containers \
             --platform ${{ matrix.arch }} \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }} \
+            ${{ env.IMAGE_NAME }} \
             -test.parallel=1 -test.timeout=1h -test.v -test.run "TestPulumiTemplateTests|TestEnvironment"
       - name: Push image
         run: |
-          docker push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}
+          docker push ${{ env.IMAGE_NAME }}
+      - name: Push default language version image
+        if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
+        run: |
+          docker tag ${{ env.IMAGE_NAME }} ${{ env.DEFAULT_IMAGE_NAME }}
+          docker push ${{ env.DEFAULT_IMAGE_NAME }}
+
+  define-matrix-sdk-manifests:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.define-matrix-sdk-manifests.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@master
+      - name: Define Matrix for SDK Manifests
+        id: define-matrix-sdk-manifests
+        run: |
+          echo matrix=$(python ./.github/scripts/gen-matrix.py) >> "$GITHUB_OUTPUT"
+
   debian-sdk-manifests:
     name: Debian SDK manifests
-    needs: ["debian-sdk"]
+    needs: ["debian-sdk", "define-matrix-sdk-manifests"]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sdk: ["nodejs", "python", "dotnet", "go", "java"]
+      matrix: ${{ fromJSON(needs.define-matrix-sdk-manifests.outputs.matrix) }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -373,27 +406,54 @@ jobs:
       - name: Debian manifest
         run: |
           docker manifest create \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-amd64
+          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian
+      - name: Debian manifest without language version suffix
+        if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
+        run: |
+          docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-amd64
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian
-      - name: Suffix-less manifest
+      - name: Manifest without debian suffix
+        run: |
+          docker manifest create \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }} \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-amd64
+          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}
+      - name: Manifest without debian suffix, without language version suffix
+        if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
         run: |
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }} \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-amd64
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}
-      - name: Suffix-less manifest (latest)
+      - name: Latest manifest
         # Manifest lists can't be a source for `docker tag`, so we create an
         # additional copy of the previous manifest to tag latest:
-        if: ${{ github.event.inputs.tag_latest || github.event_name == 'repository_dispatch' }}
+        if: ${{ (github.event.inputs.tag_latest || github.event_name == 'repository_dispatch') }}
+        run: |
+          docker manifest create \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:latest \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-amd64
+          docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:latest
+      - name: Latest manifest, without language version suffix
+        # Manifest lists can't be a source for `docker tag`, so we create an
+        # additional copy of the previous manifest to tag latest:
+        if: ${{ (github.event.inputs.tag_latest || github.event_name == 'repository_dispatch') && (matrix.default == true) && (matrix.suffix != '') }}
         run: |
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:latest \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
-            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-amd64
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-arm64 \
+            ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-debian-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:latest
+
 
   ubi-sdk:
     name: UBI SDK images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add per-language versions of the `pulumi/pulumi-python` image
+  ([#226](https://github.com/pulumi/pulumi-docker-containers/pull/226))
+
 - Unpin Azure CLI tools ([#214])(https://github.com/pulumi/pulumi-docker-containers/pull/214)
 
 - Ensure that the containers are compatible with deployments

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:11-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for dotnet"
 WORKDIR /pulumi/projects
 
-ARG DOTNET_VERSION="6.0"
+ARG LANGUAGE_VERSION
 
 RUN apt-get update -y && \
     apt-get install -y \
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 # Install dotnet 6.0 using instructions from:
 # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -channel ${DOTNET_VERSION}
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- -channel ${LANGUAGE_VERSION}
 
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:bionic AS builder
 
 ARG PULUMI_VERSION
-ARG GO_RUNTIME_VERSION=1.21.1
+ARG LANGUAGE_VERSION
 ENV GO_RUNTIME_386_SHA256 b93850666cdadbd696a986cf7b03111fe99db8c34a9aaa113d7c96d0081e1901
 ENV GO_RUNTIME_AMD64_SHA256 b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae
 ENV GO_RUNTIME_ARM64_SHA256 7da1a3936a928fd0b2602ed4f3ef535b8cd1990f1503b8d3e1acc0fa0759c967
@@ -42,7 +42,7 @@ RUN case $(uname -m) in \
     GO_RUNTIME_SHA256="${GO_RUNTIME_ARMV6L_SHA256}" \
     ;; \
     esac && \
-    curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${GO_RUNTIME_VERSION}.linux-${ARCH}.tar.gz && \
+    curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${LANGUAGE_VERSION}.linux-${ARCH}.tar.gz && \
     echo "${GO_RUNTIME_SHA256} /tmp/go.tgz" | sha256sum -c -; \
     mkdir -p bin; \
     tar -C /golang -xzf /tmp/go.tgz; \

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
+ARG LANGUAGE_VERSION
+
 FROM debian:bullseye-slim AS builder
 ARG PULUMI_VERSION
 RUN apt-get update -y && \
@@ -15,7 +17,7 @@ RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 
 # The runtime container
-FROM node:18-bullseye-slim
+FROM node:${LANGUAGE_VERSION}-bullseye-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for nodejs"
 WORKDIR /pulumi/projects
 

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
-ARG PYTHON_VERSION=3.9
+ARG LANGUAGE_VERSION
 
 FROM debian:buster-slim AS builder
 ARG PULUMI_VERSION
@@ -16,7 +16,7 @@ RUN apt-get update -y && \
 RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
-FROM python:${PYTHON_VERSION}-slim
+FROM python:${LANGUAGE_VERSION}-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for python"
 WORKDIR /pulumi/projects
 


### PR DESCRIPTION
Create per language version images for python 3.9 to 3.12. The image without suffix `pulumi/pulumi-python` continues to use 3.9.

Other languages or UBI based images are not matrixed, but this PR puts in place most of the infrastructure for this. To generate the matrix, we use a python script that creates a list of `include` entries for the matrix. We do this instead of using the normal way to specify a matrix using variables because each language has its own range of versions.

For example for Python 3.12 we get the tags/manifests:
* pulumi-python-3.12:latest
* pulumi-python-3.12:3.127.0
* pulumi-python-3.12:3.127.0-debian
* pulumi-python-3.12:3.127.0-debian-arm64
* pulumi-python-3.12:3.127.0-debian-amd64

Example on my docker hub: https://hub.docker.com/repository/docker/jpoissonnier/pulumi-python-3.12/tags

```
docker run --rm -it --entrypoint python jpoissonnier/pulumi-python-3.12:latest --version
Python 3.12.4
```