### PR TITLE
Cache go dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,10 @@ on:
     types:
       - ci-build
   pull_request:
-    paths:
-      - "docker/**"
-      - "tests/**"
-      - "!README.md"
-      - "!LICENSE"
+    paths-ignore:
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "README.md"
   # "Push" is a somewhat unintuitive name - the event will fire after a PR is
   # merged to the main branch.
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,10 @@ jobs:
             --load \
             docker/pulumi
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |
@@ -162,9 +163,10 @@ jobs:
             --load \
             docker/pulumi
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |
@@ -261,9 +263,10 @@ jobs:
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |
@@ -345,9 +348,10 @@ jobs:
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,10 @@ jobs:
             --load \
             docker/pulumi
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |
@@ -155,9 +156,10 @@ jobs:
             --load \
             docker/pulumi
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |
@@ -303,9 +305,10 @@ jobs:
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
       - name: Compile tests
         working-directory: tests
         run: |
@@ -427,9 +430,11 @@ jobs:
             docker/${{ matrix.sdk }} \
             --load
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.22"
+          cache-dependency-path: tests/go.sum
+
       - name: Compile tests
         working-directory: tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,7 +434,6 @@ jobs:
         with:
           go-version: "1.22"
           cache-dependency-path: tests/go.sum
-
       - name: Compile tests
         working-directory: tests
         run: |


### PR DESCRIPTION
Update the go action and setup caching and run the CI workflow when tests or CI workflow definitions change.