### PR TITLE
Add $GOPATH/bin to $PATH for go containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add $GOPATH/bin to $PATH for Go containers
+  ([249](https://github.com/pulumi/pulumi-docker-containers/pull/249))
+
 - Ensure corepack is installed in the `pulumi/pulumi` image
   ([#247](https://github.com/pulumi/pulumi-docker-containers/pull/247))
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -73,6 +73,6 @@ COPY --from=builder /root/.pulumi/bin/pulumi-language-go /pulumi/bin/pulumi-lang
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/pulumi-analyzer-policy
 ENV GOPATH=/go
 ENV CGO_ENABLED=0
-ENV PATH "/pulumi/bin:${PATH}"
+ENV PATH "/pulumi/bin:${GOPATH}/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/go/Dockerfile.ubi
+++ b/docker/go/Dockerfile.ubi
@@ -54,6 +54,6 @@ COPY --from=builder /root/.pulumi/bin/pulumi-language-go /pulumi/bin/pulumi-lang
 COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/pulumi-analyzer-policy
 ENV GOPATH=/go
 ENV CGO_ENABLED=0
-ENV PATH "/pulumi/bin:${PATH}"
+ENV PATH "/pulumi/bin:${GOPATH}/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -263,17 +263,15 @@ func TestEnvironment(t *testing.T) {
 		expectedPaths := map[string]string{
 			"pulumi":               "/usr/share/dotnet:/pulumi/bin:/go/bin:/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"pulumi-debian-dotnet": "/root/.dotnet:/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			// TODO: does not include $GOPATH/bin https://github.com/pulumi/pulumi-docker-containers/issues/220
-			"pulumi-debian-go":     "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"pulumi-debian-go":     "/pulumi/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"pulumi-debian-java":   "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"pulumi-debian-nodejs": "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"pulumi-debian-python": "/pulumi/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"pulumi-ubi-dotnet":    "/root/.dotnet:/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			// TODO: does not include $GOPATH/bin https://github.com/pulumi/pulumi-docker-containers/issues/220
-			"pulumi-ubi-go":     "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"pulumi-ubi-java":   "/pulumi/bin:/root/.sdkman/candidates/maven/current/bin:/root/.sdkman/candidates/gradle/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"pulumi-ubi-nodejs": "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"pulumi-ubi-python": "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"pulumi-ubi-go":        "/pulumi/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"pulumi-ubi-java":      "/pulumi/bin:/root/.sdkman/candidates/maven/current/bin:/root/.sdkman/candidates/gradle/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"pulumi-ubi-nodejs":    "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"pulumi-ubi-python":    "/pulumi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		}
 
 		t.Run("PATH when running in bash", func(t *testing.T) {


### PR DESCRIPTION
Add `$GOPATH/bin` to `$PATH` so that go based tools can easily be installed in the container. This matches the setup in the `pulumi/pulumi` image.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/220