### PR TITLE
Matrix Nodejs debian images across LTS versions

### DIFF
--- a/.github/scripts/matrix/gen-matrix.py
+++ b/.github/scripts/matrix/gen-matrix.py
@@ -78,4 +78,26 @@ for arch in archs:
             )
         )
 
+    # Default Nodejs version
+    matrix["include"].append(
+        make_entry(
+            sdk="nodejs",
+            arch=arch,
+            language_version=versions.nodejs_default_version,
+            default=True,
+            suffix=f"-{versions.nodejs_default_version}",
+        )
+    )
+    # Additional Nodejs versions
+    for version in versions.nodejs_additional_versions:
+        matrix["include"].append(
+            make_entry(
+                sdk="nodejs",
+                arch=arch,
+                language_version=version,
+                default=False,
+                suffix=f"-{version}",
+            )
+        )
+
 print(json.dumps(matrix))

--- a/.github/scripts/matrix/gen-sync-matrix.py
+++ b/.github/scripts/matrix/gen-sync-matrix.py
@@ -5,13 +5,15 @@
 # matrix = {
 #     "image": [
 #         "pulumi-base",
-#         "pulumi-nodejs",
 #         "pulumi-go",
 #         "pulumi-dotnet",
 #         "pulumi-java",
 #         "pulumi-python",
 #         "pulumi-python-3.9",
 #         "pulumi-python-3.10"
+#         "pulumi-nodejs",
+#         "pulumi-nodejs-18",
+#         "pulumi-nodejs-20",
 #         ...
 #     ]
 # }
@@ -34,5 +36,12 @@ matrix["image"].append("pulumi-python")
 # Python with version suffixes
 for version in [versions.python_default_version, *versions.python_additional_versions]:
     matrix["image"].append(f"pulumi-python-{version}")
+
+# Nodejs without suffix
+matrix["image"].append("pulumi-nodejs")
+
+# Nodejs with version suffixes
+for version in [versions.nodejs_default_version, *versions.nodejs_additional_versions]:
+    matrix["image"].append(f"pulumi-nodejs-{version}")
 
 print(json.dumps(matrix))

--- a/.github/scripts/matrix/versions.py
+++ b/.github/scripts/matrix/versions.py
@@ -1,14 +1,15 @@
 # SDKs without version suffixes.
 # For these SDKs we only have unsuffixed images, for example `pulumi-dotnet` and `pulumi-go`.
 sdks = {
-    "nodejs": "18",
     "go": "1.21.1",
     "dotnet": "6.0",
     "java": "not-used-yet",
 }
 
-# For Python we have a default version and additional versions with suffixes.
+# For Python and Nodejs we have a default version and additional versions with suffixes.
 # The default version is used for the unsuffixed image `pulumi-python` and for the suffixed version `pulumi-python-3.9`.
 # The additional versions are used for the suffixed images `pulumi-python-3.10`, `pulumi-python-3.11`, ...
 python_default_version = "3.9"
 python_additional_versions = ["3.10", "3.11", "3.12"]
+nodejs_default_version = "18"
+nodejs_additional_versions = ["20", "22"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add per-language versions of the `pulumi/pulumi-nodejs` image
+  ([#255](https://github.com/pulumi/pulumi-docker-containers/pull/255))
+
 - Include jq in the kitchen sink image
   ([#258](https://github.com/pulumi/pulumi-docker-containers/pull/258))
 


### PR DESCRIPTION
Introduce new images for each Nodejs LTS version: `pulumi-nodejs-{18,20,22}`. The `pulumi-nodejs` image continues to use Nodejs 18.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/254
