### PR TITLE
Matrix dotnet debian images

### DIFF
--- a/.github/scripts/matrix/gen-matrix.py
+++ b/.github/scripts/matrix/gen-matrix.py
@@ -37,6 +37,7 @@ INCLUDE_ARCH = False if len(sys.argv) > 1 and sys.argv[1] == "--no-arch" else Tr
 archs = ["amd64", "arm64"] if INCLUDE_ARCH else [None]
 matrix = {"include": []}
 
+
 def make_entry(*, sdk, arch, default, language_version=None, suffix=None):
     entry = {
         "sdk": sdk,
@@ -55,11 +56,14 @@ for arch in archs:
 
     for sdk in versions.unversioned:
         # Default (and only) version for unversioned SDKs
-        matrix["include"].append(
-            make_entry(sdk=sdk, arch=arch, default=True)
-        )
+        matrix["include"].append(make_entry(sdk=sdk, arch=arch, default=True))
 
     for sdk, info in versions.versioned.items():
+        # We use QEMU to run ARM64 images on AMD64, but .NET Core isn't supported by QEMU, skip it.
+        # https://gitlab.com/qemu-project/qemu/-/issues/249
+        if sdk == "dotnet" and arch == "arm64":
+            continue
+
         # Default version
         matrix["include"].append(
             make_entry(

--- a/.github/scripts/matrix/gen-matrix.py
+++ b/.github/scripts/matrix/gen-matrix.py
@@ -59,11 +59,6 @@ for arch in archs:
         matrix["include"].append(make_entry(sdk=sdk, arch=arch, default=True))
 
     for sdk, info in versions.versioned.items():
-        # We use QEMU to run ARM64 images on AMD64, but .NET Core isn't supported by QEMU, skip it.
-        # https://gitlab.com/qemu-project/qemu/-/issues/249
-        if sdk == "dotnet" and arch == "arm64":
-            continue
-
         # Default version
         matrix["include"].append(
             make_entry(

--- a/.github/scripts/matrix/gen-sync-matrix.py
+++ b/.github/scripts/matrix/gen-sync-matrix.py
@@ -27,21 +27,15 @@ matrix = {"image": [
 ]}
 
 # Images without language versions
-for sdk in versions.sdks:
+for sdk in versions.unversioned:
     matrix["image"].append(f"pulumi-{sdk}")
 
-# Python without suffix
-matrix["image"].append("pulumi-python")
-
-# Python with version suffixes
-for version in [versions.python_default_version, *versions.python_additional_versions]:
-    matrix["image"].append(f"pulumi-python-{version}")
-
-# Nodejs without suffix
-matrix["image"].append("pulumi-nodejs")
-
-# Nodejs with version suffixes
-for version in [versions.nodejs_default_version, *versions.nodejs_additional_versions]:
-    matrix["image"].append(f"pulumi-nodejs-{version}")
+for sdk, info in versions.versioned.items():
+    # Without suffix
+    matrix["image"].append(f"pulumi-{sdk}")
+    matrix["image"].append(f"pulumi-{sdk}-{info['default']}")
+    # Additional versions with suffixes
+    for version in info["additional"]:
+        matrix["image"].append(f"pulumi-{sdk}-{version}")
 
 print(json.dumps(matrix))

--- a/.github/scripts/matrix/versions.py
+++ b/.github/scripts/matrix/versions.py
@@ -1,15 +1,21 @@
 # SDKs without version suffixes.
-# For these SDKs we only have unsuffixed images, for example `pulumi-dotnet` and `pulumi-go`.
-sdks = {
-    "go": "1.21.1",
-    "dotnet": "6.0",
-    "java": "not-used-yet",
-}
+# For these SDKs we only have unsuffixed images, for example `pulumi-java` and `pulumi-go`.
+unversioned = ["go", "java"]
 
-# For Python and Nodejs we have a default version and additional versions with suffixes.
+# For the versioned SDKS we have a default version and additional versions with suffixes.
 # The default version is used for the unsuffixed image `pulumi-python` and for the suffixed version `pulumi-python-3.9`.
 # The additional versions are used for the suffixed images `pulumi-python-3.10`, `pulumi-python-3.11`, ...
-python_default_version = "3.9"
-python_additional_versions = ["3.10", "3.11", "3.12"]
-nodejs_default_version = "18"
-nodejs_additional_versions = ["20", "22"]
+versioned = {
+    "nodejs": {
+        "default": "18",
+        "additional": ["20", "22"]
+    },
+    "python": {
+        "default": "3.9",
+        "additional": ["3.10", "3.11", "3.12"]
+    },
+    "dotnet": {
+        "default": "6.0",
+        "additional": ["8.0"]
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,11 @@ jobs:
             }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
-      - name: Tests
+      - if: ${{ !(matrix.arch == 'amd64' && matrix.sdk == 'dotnet') }}
+        # We use QEMU to run ARM64 images on AMD64, but .NET Core isn't supported by QEMU, skip
+        # running the tests for this combination.
+        # https://gitlab.com/qemu-project/qemu/-/issues/249
+        name: Tests
         run: |
           docker run \
             -e RUN_CONTAINER_TESTS=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
             }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
-      - if: ${{ !(matrix.arch == 'amd64' && matrix.sdk == 'dotnet') }}
+      - if: ${{ !(matrix.arch == 'arm64' && matrix.sdk == 'dotnet') }}
         # We use QEMU to run ARM64 images on AMD64, but .NET Core isn't supported by QEMU, skip
         # running the tests for this combination.
         # https://gitlab.com/qemu-project/qemu/-/issues/249

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add per-language versions of the `pulumi/pulumi-dotnet` image
+  ([#257](https://github.com/pulumi/pulumi-docker-containers/pull/257))
+
 - Add per-language versions of the `pulumi/pulumi-nodejs` image
   ([#255](https://github.com/pulumi/pulumi-docker-containers/pull/255))
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:bionic AS builder
 
 ARG PULUMI_VERSION
-ARG LANGUAGE_VERSION
+ARG GO_RUNTIME_VERSION=1.21.1
 ENV GO_RUNTIME_386_SHA256 b93850666cdadbd696a986cf7b03111fe99db8c34a9aaa113d7c96d0081e1901
 ENV GO_RUNTIME_AMD64_SHA256 b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae
 ENV GO_RUNTIME_ARM64_SHA256 7da1a3936a928fd0b2602ed4f3ef535b8cd1990f1503b8d3e1acc0fa0759c967
@@ -42,7 +42,7 @@ RUN case $(uname -m) in \
     GO_RUNTIME_SHA256="${GO_RUNTIME_ARMV6L_SHA256}" \
     ;; \
     esac && \
-    curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${LANGUAGE_VERSION}.linux-${ARCH}.tar.gz && \
+    curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${GO_RUNTIME_VERSION}.linux-${ARCH}.tar.gz && \
     echo "${GO_RUNTIME_SHA256} /tmp/go.tgz" | sha256sum -c -; \
     mkdir -p bin; \
     tar -C /golang -xzf /tmp/go.tgz; \


### PR DESCRIPTION
Create suffixed images for dotnet: pulumi-dotnet-6.0 & pulumi-dotnet-8.0. The pulumi-dotnet image continues to use dotnet 6.0.