### PR TITLE
Install jq in kitchen sink image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Include jq in the kitchen sink image
+  ([#258](https://github.com/pulumi/pulumi-docker-containers/pull/258))
+
 - Include pyenv and Python 3.9 to 3.12 in the kitchen sink image
   ([#232](https://github.com/pulumi/pulumi-docker-containers/pull/232))
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -y && \
   ca-certificates \
   curl \
   git \
+  jq \
   gnupg \
   libbz2-dev \
   libffi-dev \


### PR DESCRIPTION
This images is used for pulumi devcontainer and running many pulumi make commands require jq installed