### PR TITLE
Add id-token permissions to release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
       matrix:
         go-version: [1.21.x]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@master
       - name: Free Disk Space (Ubuntu)
@@ -154,6 +156,8 @@ jobs:
       matrix:
         go-version: [1.21.1]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@master
       - name: Free Disk Space (Ubuntu)
@@ -330,6 +334,8 @@ jobs:
     name: Debian SDK images
     needs: define-matrix
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
@@ -517,6 +523,8 @@ jobs:
   ubi-sdk:
     name: UBI SDK images
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We need this to auth with GCP

Follow up to https://github.com/pulumi/pulumi-docker-containers/pull/263
