### PR TITLE
Fix release & and sync jobs for ubi images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,6 +553,11 @@ jobs:
       - name: Set image name
         run: |
           echo "IMAGE_NAME=${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-ubi" >> $GITHUB_ENV
+      - name: Set default language version image name
+        # For the default language version, we also set a default image name that doesn't include the version suffix
+        if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
+        run: |
+          echo "DEFAULT_IMAGE_NAME=${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}" >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -640,6 +645,12 @@ jobs:
       - name: Push image
         run: |
           docker push ${{ env.IMAGE_NAME }}
+      - name: Push default language version image
+        if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
+        run: |
+          docker tag ${{ env.IMAGE_NAME }} ${{ env.DEFAULT_IMAGE_NAME }}
+          docker push ${{ env.DEFAULT_IMAGE_NAME }}
+
 
   start-syncs:
     name: Start syncs to other container registries

--- a/.github/workflows/sync-ecr.yml
+++ b/.github/workflows/sync-ecr.yml
@@ -143,8 +143,14 @@ jobs:
       - uses: actions/checkout@master
       - name: Define Matrix
         id: define-matrix
+        # Filter out the nodejs 22 and version from the matrix, as it is not supported on UBI.
+        # https://access.redhat.com/articles/3376841
+        # Filter out the python 3.10 version from the matrix, as it is not supported on UBI.
+        # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_introduction-to-python_installing-and-using-dynamic-programming-languages#con_python-versions_assembly_introduction-to-python
         run: |
-          echo matrix=$(python ./.github/scripts/matrix/gen-sync-matrix.py) >> "$GITHUB_OUTPUT"
+          echo matrix=$(python ./.github/scripts/matrix/gen-sync-matrix.py |
+            jq '.image |= map(select(. != "pulumi-python-3.10" and . != "pulumi-nodejs-22"))'
+          ) >> "$GITHUB_OUTPUT"
 
   # NOTE: If UBI images become multi platform, this job can be replaced by adding a similar step to "-debian" for "-ubi" the previous job.
   ubi-images:

--- a/.github/workflows/sync-ghcr.yml
+++ b/.github/workflows/sync-ghcr.yml
@@ -122,8 +122,14 @@ jobs:
       - uses: actions/checkout@master
       - name: Define Matrix
         id: define-matrix
+          # Filter out the nodejs 22 and version from the matrix, as it is not supported on UBI.
+          # https://access.redhat.com/articles/3376841
+          # Filter out the python 3.10 version from the matrix, as it is not supported on UBI.
+          # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_introduction-to-python_installing-and-using-dynamic-programming-languages#con_python-versions_assembly_introduction-to-python
         run: |
-          echo matrix=$(python ./.github/scripts/matrix/gen-sync-matrix.py) >> "$GITHUB_OUTPUT"
+          echo matrix=$(python ./.github/scripts/matrix/gen-sync-matrix.py |
+            jq '.image |= map(select(. != "pulumi-python-3.10" and . != "pulumi-nodejs-22"))'
+          ) >> "$GITHUB_OUTPUT"
 
   # NOTE: If UBI images become multi platform, this job can be replaced by adding a similar step to "-debian" for "-ubi" the previous job.
   ubi-images:


### PR DESCRIPTION
We need to push the default images for the UBI variants ,for example
pulumi-python:3:134.0-ubi.

We also need to skip trying to sync the versions for Python 3.10 and
Nodejs 22 for UBI, since these do not exist, see https://github.com/pulumi/pulumi-docker-containers/blob/fdcbab706212b8e2aafa55470934a3cabe05447e/.github/workflows/ci.yml#L395-L398

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/279
Fixes https://github.com/pulumi/pulumi-docker-containers/issues/278