### PR TITLE
Update doc on default Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Images are pushed to:
 
 - .NET 6.0
 - Go 1.21
-- JDK 11
+- JDK 17
 - Node.js 18
 - Python 3.9
 


### PR DESCRIPTION
The default Java version was bumped to 17 when we updated the base OS to Debian 12. We had never actually published the Java images before to any registry, so we didn't hold back this update.