### PR TITLE
Fix release for pulumi:latest-nonroot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
             -f docker/pulumi/Dockerfile \
             --platform linux/amd64 \
             -t ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot \
+            -t ${{ env.DOCKER_ORG }}/pulumi:latest-nonroot \
             --target nonroot \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
             --load \


### PR DESCRIPTION
We need to create the tag `latest-nonroot` during the build so we can later (conditionally) push it.
