### PR TITLE
Fix copy-pasta in ubi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}
-            
+
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot-arm64 \
@@ -215,7 +215,7 @@ jobs:
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi:latest
-      
+
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi:latest-nonroot \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot-arm64 \
@@ -651,7 +651,7 @@ jobs:
         # For the default language version, we also set a default image name that doesn't include the version suffix
         if: ${{ (matrix.default == true) && (matrix.suffix != '') }}
         run: |
-          echo "DEFAULT_IMAGE_NAME=${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-debian-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DEFAULT_IMAGE_NAME=${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi" >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
The default image name was copied from the debian version without adapting it.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/291
Fixes https://github.com/pulumi/pulumi-docker-containers/issues/290