### PR TITLE
Disable arm64 build for kitchen sink and provider-build-environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,10 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.x]
-        arch: ["arm64", "amd64"]
+        # Disabling arm64 for now as it takes too long to build Python when running Docker with QEMU.
+        # Once arm64 runners are availble to OSS projects, we can re-enable this.
+        # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
+        arch: ["amd64"] # "arm64"
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -83,8 +86,6 @@ jobs:
         with:
           install: true
       - name: Build
-        # We only build the "kitchen sink" image for AMD64 as it's rather large
-        # and we want to steer users to use the single SDK images going forward:
         run: |
           docker build \
             -f docker/pulumi/Dockerfile \
@@ -205,15 +206,14 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Versioned manifest
         run: |
+          # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }} \
-            ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}
 
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot \
-            ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot
       - name: Latest manifest
@@ -223,13 +223,11 @@ jobs:
         run: |
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi:latest \
-            ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi:latest
 
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi:latest-nonroot \
-            ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}-nonroot-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi:latest-nonroot
   provider-build-environment:
@@ -237,7 +235,10 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.1]
-        arch: ["arm64", "amd64"]
+        # Disabling arm64 for now as it takes too long to build Python when running Docker with QEMU.
+        # Once arm64 runners are availble to OSS projects, we can re-enable this.
+        # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
+        arch: ["amd64"] # "arm64"
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -264,7 +265,7 @@ jobs:
         run: |
           docker build \
             -f docker/pulumi/Dockerfile \
-            --platform linux/amd64 \
+            --platform linux/${{ matrix.arch }} \
             -t ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }}-${{ matrix.arch }} \
             --target build-environment \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \
@@ -336,7 +337,6 @@ jobs:
         run: |
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }} \
-            ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }}-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }}-amd64
       - name: Latest manifest
         if: ${{ github.event.inputs.tag_latest || github.event_name == 'repository_dispatch' }}
@@ -345,7 +345,6 @@ jobs:
         run: |
           docker manifest create \
             ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:latest \
-            ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }}-arm64 \
             ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }}-amd64
           docker manifest push ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:latest
 

--- a/.github/workflows/sync-ecr.yml
+++ b/.github/workflows/sync-ecr.yml
@@ -49,11 +49,12 @@ jobs:
             --query 'authorizationData.authorizationToken' | \
             tr -d '"' | base64 --decode | cut -d: -f2 | \
             docker login -u AWS --password-stdin https://public.ecr.aws
-      - name: Tag ${{ env.PULUMI_VERSION }}-arm64 and push to AWS Public ECR
-        run: |
-          docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
-          docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
-          docker push public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
+      # - name: Tag ${{ env.PULUMI_VERSION }}-arm64 and push to AWS Public ECR
+      #   run: |
+      #     docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      #     docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      #     docker push public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
       - name: Tag ${{ env.PULUMI_VERSION }}-amd64 and push to AWS Public ECR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64
@@ -62,10 +63,10 @@ jobs:
       - name: Push latest manifest
         if: ${{ github.event.inputs.tag_latest || github.event_name == 'repository_dispatch' }}
         run: |
+          # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
           docker manifest create \
             public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:latest${{ matrix.suffix }} \
-            public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64 \
-            public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+            public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64
           docker manifest push public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:latest${{ matrix.suffix }}
 
   define-debian-matrix:

--- a/.github/workflows/sync-ghcr.yml
+++ b/.github/workflows/sync-ghcr.yml
@@ -39,11 +39,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Tag ${{ env.PULUMI_VERSION }}-arm64 and push to GHCR
-        run: |
-          docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
-          docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
-          docker push ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
+      # - name: Tag ${{ env.PULUMI_VERSION }}-arm64 and push to GHCR
+      #   run: |
+      #     docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      #     docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      #     docker push ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
       - name: Tag ${{ env.PULUMI_VERSION }}-amd64 and push to GHCR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64
@@ -52,10 +53,10 @@ jobs:
       - name: Push latest manifest to GHCR
         if: ${{ github.event.inputs.tag_latest || github.event_name == 'repository_dispatch' }}
         run: |
+          # TODO: https://github.com/pulumi/pulumi-docker-containers/issues/297
           docker manifest create \
             ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:latest${{ matrix.suffix }} \
-            ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64 \
-            ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+            ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64
           docker manifest push ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:latest${{ matrix.suffix }}
 
   define-debian-matrix:


### PR DESCRIPTION
We had to disable the release builds of these images on arm64 because it takes too long to install the Python versions provided by the image when running in Docker + QEMU.

ARM64 runners should become available for OSS projects later this year, see https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/
Once we can use these, we can re-enable the ARM64 build.

Ref https://github.com/pulumi/pulumi-docker-containers/issues/297
