### PR TITLE
Add Node.js 23 and Python 3.13 to the kitchen sink and as per-language versions

### DIFF
--- a/.github/scripts/matrix/versions.py
+++ b/.github/scripts/matrix/versions.py
@@ -8,11 +8,11 @@ unversioned = ["go", "java"]
 versioned = {
     "nodejs": {
         "default": "18",
-        "additional": ["20", "22"]
+        "additional": ["20", "22", "23"]
     },
     "python": {
         "default": "3.9",
-        "additional": ["3.10", "3.11", "3.12"]
+        "additional": ["3.10", "3.11", "3.12", "3.13"]
     },
     "dotnet": {
         "default": "6.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,16 +426,18 @@ jobs:
       - uses: actions/checkout@master
       - name: Define Matrix for UBI SDK Manifests
         id: define-matrix-sdk-manifests
-        # Filter out the nodejs 22 and version from the matrix, as it is not supported on UBI.
+        # Filter out the nodejs 22 and 23 versions from the matrix, as they are not supported on UBI.
         # https://access.redhat.com/articles/3376841
-        # Filter out the python 3.10 version from the matrix, as it is not supported on UBI.
+        # Filter out the python 3.10 and 3.13 versions from the matrix, as they are supported on UBI.
         # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_introduction-to-python_installing-and-using-dynamic-programming-languages#con_python-versions_assembly_introduction-to-python
         run: |
           echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch |
             jq '.include |= map(
               select(
                 (.sdk != "nodejs" or .language_version != "22") and
-                (.sdk != "python" or .language_version != "3.10")
+                (.sdk != "nodejs" or .language_version != "23") and
+                (.sdk != "python" or .language_version != "3.10") and
+                (.sdk != "python" or .language_version != "3.13")
               )
             )') >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add Node.js 23 and Python 3.13 to the kitchen sink and as per-language versions
+  ([#309](https://github.com/pulumi/pulumi-docker-containers/pull/309)
+
 - Add nonroot variant for the kitchen sink image
 ([#277](https://github.com/pulumi/pulumi-docker-containers/pull/277)
 


### PR DESCRIPTION
New language versions are out, let’s get then into the kitchen sink and as slim language specific versions.
