### PR TITLE
Skip Node.js 23 and Python 3.13 for UBI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,7 +633,7 @@ jobs:
         id: define-matrix
         # Filter out the nodejs 22 and 23 versions from the matrix, as they are not supported on UBI.
         # https://access.redhat.com/articles/3376841
-        # Filter out the python 3.10 and 3.13 versions from the matrix, as they are supported on UBI.
+        # Filter out the python 3.10 and 3.13 versions from the matrix, as they are not supported on UBI.
         # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_introduction-to-python_installing-and-using-dynamic-programming-languages#con_python-versions_assembly_introduction-to-python
         run: |
           echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -631,16 +631,18 @@ jobs:
       - uses: actions/checkout@master
       - name: Define Matrix for UBI SDK Manifests
         id: define-matrix
-        # Filter out the nodejs 22 and version from the matrix, as it is not supported on UBI.
+        # Filter out the nodejs 22 and 23 versions from the matrix, as they are not supported on UBI.
         # https://access.redhat.com/articles/3376841
-        # Filter out the python 3.10 version from the matrix, as it is not supported on UBI.
+        # Filter out the python 3.10 and 3.13 versions from the matrix, as they are supported on UBI.
         # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_introduction-to-python_installing-and-using-dynamic-programming-languages#con_python-versions_assembly_introduction-to-python
         run: |
           echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch |
             jq '.include |= map(
               select(
                 (.sdk != "nodejs" or .language_version != "22") and
-                (.sdk != "python" or .language_version != "3.10")
+                (.sdk != "nodejs" or .language_version != "23") and
+                (.sdk != "python" or .language_version != "3.10") and
+                (.sdk != "python" or .language_version != "3.13")
               )
             )') >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Added for CI in https://github.com/pulumi/pulumi-docker-containers/pull/309, but  I forgot to add this to the release workflow