### PR TITLE
Skip template tests on .NET 6.0 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,7 @@ jobs:
           docker run \
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi-debian-${{ matrix.sdk }} \
+            -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
@@ -521,6 +522,7 @@ jobs:
           docker run \
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi-ubi-${{ matrix.sdk }} \
+            -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -63,6 +63,8 @@ func TestPulumiTemplateTests(t *testing.T) {
 
 	stackOwner := mustEnv(t, "PULUMI_ORG")
 
+	languageVersion := os.Getenv("LANGUAGE_VERSION") // Not set for kitchen sink
+
 	sdksToTest := []string{"csharp", "python", "typescript", "go", "java"}
 	if os.Getenv("SDKS_TO_TEST") != "" {
 		sdksToTest = strings.Split(os.Getenv("SDKS_TO_TEST"), ",")
@@ -80,10 +82,15 @@ func TestPulumiTemplateTests(t *testing.T) {
 
 	testCases := []testCase{}
 	for _, sdk := range sdksToTest {
-		// python, typescript, ...
+		if sdk == "csharp" && languageVersion == "6.0" {
+			// .NET 6.0 is not supported by our templates anymore.
+			// require.True(t, false)
+			continue
+		}
+		// Base language templates: python, typescript, ...
 		testCases = append(testCases, testCase{sdk, map[string]string{}})
 		for _, cloud := range clouds {
-			// azure-python, aws-python, ...
+			// Cloud templates azure-python, aws-python, ...
 			if sdk == "typescript" && cloud == "azure" {
 				// We use docker & qemu to run arm64 images, and azure seems to be too large
 				// to successfully run in that environment.

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -84,7 +84,6 @@ func TestPulumiTemplateTests(t *testing.T) {
 	for _, sdk := range sdksToTest {
 		if sdk == "csharp" && languageVersion == "6.0" {
 			// .NET 6.0 is not supported by our templates anymore.
-			// require.True(t, false)
 			continue
 		}
 		// Base language templates: python, typescript, ...


### PR DESCRIPTION
Our templates have been updated to use .NET 8.0, so they won't run anymore on .NET 6.0.
