### PR TITLE
Skip dotnet 6.0 tests in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,6 +519,7 @@ jobs:
           docker run \
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi-debian-${{ matrix.sdk }} \
+            -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
@@ -729,6 +730,7 @@ jobs:
           docker run \
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi-ubi-${{ matrix.sdk }} \
+            -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \


### PR DESCRIPTION
Pass through the language version, so we can skip the donet template tests when running on dotnet 6.0. Our templates have been updated to use 8.0

Follow up to https://github.com/pulumi/pulumi-docker-containers/pull/320 which updated the PR workflow, but not the release workflow.
