### PR TITLE
Fix sync jobs

### DIFF
--- a/.github/workflows/sync-ecr.yml
+++ b/.github/workflows/sync-ecr.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Define Matrix
         id: define-matrix
         run: |
-          echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch) >> "$GITHUB_OUTPUT"
+          echo matrix=$(python ./.github/scripts/matrix/gen-sync-matrix.py) >> "$GITHUB_OUTPUT"
 
   # NOTE: If UBI images become multi platform, this job can be replaced by adding a similar step to "-debian" for "-ubi" the previous job.
   ubi-images:

--- a/.github/workflows/sync-ghcr.yml
+++ b/.github/workflows/sync-ghcr.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Define Matrix
         id: define-matrix
         run: |
-          echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch) >> "$GITHUB_OUTPUT"
+          echo matrix=$(python ./.github/scripts/matrix/gen-sync-matrix.py) >> "$GITHUB_OUTPUT"
 
   # NOTE: If UBI images become multi platform, this job can be replaced by adding a similar step to "-debian" for "-ubi" the previous job.
   ubi-images:


### PR DESCRIPTION
The script got mistakently changed to `gen-matrix.py`  in https://github.com/julienp/pulumi-docker-containers/commit/4d5ec96ec3a4c80cf0c85219eb87523f0fb4e908 from

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/315
Fixes https://github.com/pulumi/pulumi-docker-containers/issues/314