### PR TITLE
Release all UBI images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,20 +632,8 @@ jobs:
       - uses: actions/checkout@master
       - name: Define Matrix for UBI SDK Manifests
         id: define-matrix
-        # Filter out the nodejs 22 and 23 versions from the matrix, as they are not supported on UBI.
-        # https://access.redhat.com/articles/3376841
-        # Filter out the python 3.10 and 3.13 versions from the matrix, as they are not supported on UBI.
-        # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_introduction-to-python_installing-and-using-dynamic-programming-languages#con_python-versions_assembly_introduction-to-python
         run: |
-          echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch |
-            jq '.include |= map(
-              select(
-                (.sdk != "nodejs" or .language_version != "22") and
-                (.sdk != "nodejs" or .language_version != "23") and
-                (.sdk != "python" or .language_version != "3.10") and
-                (.sdk != "python" or .language_version != "3.13")
-              )
-            )') >> "$GITHUB_OUTPUT"
+          echo matrix=$(python ./.github/scripts/matrix/gen-matrix.py --no-arch) >> "$GITHUB_OUTPUT"
 
   ubi-sdk:
     name: UBI SDK images


### PR DESCRIPTION
https://github.com/pulumi/pulumi-docker-containers/pull/326/ updated the UBI imags so that we can build for the missing Python and Node.js versions, but forgot to updated the release script.
