### PR TITLE
Default to Python 3.12 instead of 3.13

### DIFF
--- a/.github/scripts/matrix/versions.py
+++ b/.github/scripts/matrix/versions.py
@@ -3,7 +3,7 @@
 unversioned = ["go", "java"]
 
 # For the versioned SDKS we have a default version and additional versions with suffixes.
-# The default version is used for the unsuffixed image `pulumi-python` and for the suffixed version `pulumi-python-3.13`.
+# The default version is used for the unsuffixed image `pulumi-python` and for the suffixed version `pulumi-python-3.12`.
 # The additional versions are used for the suffixed images `pulumi-python-3.10`, `pulumi-python-3.11`, ...
 versioned = {
     "nodejs": {
@@ -11,8 +11,8 @@ versioned = {
         "additional": ["18", "20", "23"]
     },
     "python": {
-        "default": "3.13",
-        "additional": ["3.9", "3.10", "3.11", "3.12"]
+        "default": "3.12",
+        "additional": ["3.9", "3.10", "3.11", "3.13"]
     },
     "dotnet": {
         "default": "8.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Default to Python 3.12 instead of 3.13
+  ([335](https://github.com/pulumi/pulumi-docker-containers/pull/335))
+
 - Install Python and Node.js in the UBI containers using pyenv and fnm
   ([326])https://github.com/pulumi/pulumi-docker-containers/pull/326))
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Images without a version suffix use the following language versions by default:
  - Go 1.23
  - JDK 21
  - Node.js 22
- - Python 3.13
+ - Python 3.12
 
 ### Version Policy
 
-Language runtimes are kept up-to-date with current LTS versions. You can pin the image tag to a particular version in order to avoid unintended upgrades.
+Language runtimes are kept up-to-date with current LTS versions. For Python, the default version corresponds to the release prior to the latest release, for other languages thedefault version corresponds to the latest release. You can pin the image tag to a particular version in order to avoid unintended upgrades.
 
 ### Choosing a Language Version
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Images without a version suffix use the following language versions by default:
 
 ### Version Policy
 
-Language runtimes are kept up-to-date with current LTS versions. For Python, the default version corresponds to the release prior to the latest release, for other languages thedefault version corresponds to the latest release. You can pin the image tag to a particular version in order to avoid unintended upgrades.
+Language runtimes are kept up-to-date with current LTS versions. For Python, the default version corresponds to the release prior to the latest release, for other languages the default version corresponds to the latest release. You can pin the image tag to a particular version in order to avoid unintended upgrades.
 
 ### Choosing a Language Version
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -139,7 +139,7 @@ RUN pyenv install 3.12
 RUN pyenv install 3.11
 RUN pyenv install 3.10
 RUN pyenv install 3.9
-RUN pyenv global 3.13 # Default version
+RUN pyenv global 3.12 # Default version
 # Poetry
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local/share/pypoetry python3 -
 RUN ln -s /usr/local/share/pypoetry/bin/poetry /usr/local/bin/

--- a/tests/testdata/python-default/__main__.py
+++ b/tests/testdata/python-default/__main__.py
@@ -1,4 +1,4 @@
 import sys
 
-assert sys.version_info.major == 3 and sys.version_info.minor == 13, \
-    f"version should be 3.13, got {sys.version_info.major}.{sys.version_info.minor}"
+assert sys.version_info.major == 3 and sys.version_info.minor == 12, \
+    f"version should be 3.12, got {sys.version_info.major}.{sys.version_info.minor}"


### PR DESCRIPTION
To run on Python 3.13 you need at least pulumi [3.136.0](https://github.com/pulumi/pulumi/releases/tag/v3.136.0), which was released October 8. Defaulting to Python 3.13 causes issues for anyone on an older version. Python 3.12 support goes back to [3.103](https://github.com/pulumi/pulumi/releases/tag/v3.103.0), released in January.
