### PR TITLE
Add uv to images that include Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Include uv in images that provide Python
+  -([341](https://github.com/pulumi/pulumi-docker-containers/pull/341))
+
 - Default to Python 3.12 instead of 3.13
   ([335](https://github.com/pulumi/pulumi-docker-containers/pull/335))
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -146,6 +146,10 @@ RUN ln -s /usr/local/share/pypoetry/bin/poetry /usr/local/bin/
 # Set poetry to prefer the active python version so it interacts nicely with pyenv, otherwise
 # poetry will create virtual environments using the python version used by poetry itself.
 RUN poetry config virtualenvs.prefer-active-python true
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | XDG_BIN_HOME=/usr/local/share/uv bash -s -- --no-modify-path
+RUN ln -s /usr/local/share/uv/uv /usr/local/bin/
+RUN ln -s /usr/local/share/uv/uvx /usr/local/bin/
 
 # Install default nodejs versions and associated tools
 RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "/usr/local/share/fnm" --skip-shell && \

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -31,6 +31,11 @@ RUN apt-get update -y && \
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local/share/pypoetry python3 -
 RUN ln -s /usr/local/share/pypoetry/bin/poetry /usr/local/bin/
 
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | XDG_BIN_HOME=/usr/local/share/uv bash -s -- --no-modify-path
+RUN ln -s /usr/local/share/uv/uv /usr/local/bin/
+RUN ln -s /usr/local/share/uv/uvx /usr/local/bin/
+
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-python* /pulumi/bin/

--- a/docker/python/Dockerfile.ubi
+++ b/docker/python/Dockerfile.ubi
@@ -49,6 +49,11 @@ RUN pyenv global ${LANGUAGE_VERSION}
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local/share/pypoetry python3 -
 RUN ln -s /usr/local/share/pypoetry/bin/poetry /usr/local/bin/
 
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | XDG_BIN_HOME=/usr/local/share/uv bash -s -- --no-modify-path
+RUN ln -s /usr/local/share/uv/uv /usr/local/bin/
+RUN ln -s /usr/local/share/uv/uvx /usr/local/bin/
+
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-python* /pulumi/bin/

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -305,8 +305,16 @@ func TestEnvironment(t *testing.T) {
 		poetryPath, err := exec.LookPath("poetry")
 		require.NoError(t, err)
 		require.Equal(t, expectedPoetryPath, poetryPath)
-		// Use bash `command` builtin to lookup the path to python
+		// Use bash `command` builtin to lookup the path to poetry
 		requireOutputWithBash(t, expectedPoetryPath, "command", "-v", "poetry")
+
+		// uvy should be available
+		expectedUvPath := "/usr/local/bin/uv"
+		uvPath, err := exec.LookPath("uv")
+		require.NoError(t, err)
+		require.Equal(t, expectedUvPath, uvPath)
+		// Use bash `command` builtin to lookup the path to uv
+		requireOutputWithBash(t, expectedPoetryPath, "command", "-v", "uv")
 	})
 
 	t.Run("Node", func(t *testing.T) {

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -314,7 +314,7 @@ func TestEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedUvPath, uvPath)
 		// Use bash `command` builtin to lookup the path to uv
-		requireOutputWithBash(t, expectedPoetryPath, "command", "-v", "uv")
+		requireOutputWithBash(t, expectedUvPath, "command", "-v", "uv")
 	})
 
 	t.Run("Node", func(t *testing.T) {

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -308,7 +308,7 @@ func TestEnvironment(t *testing.T) {
 		// Use bash `command` builtin to lookup the path to poetry
 		requireOutputWithBash(t, expectedPoetryPath, "command", "-v", "poetry")
 
-		// uvy should be available
+		// uv should be available
 		expectedUvPath := "/usr/local/bin/uv"
 		uvPath, err := exec.LookPath("uv")
 		require.NoError(t, err)


### PR DESCRIPTION
Now that the Pulumi CLI supports uv out of the box, include it in the docker images.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/340
