### PR TITLE
Update Go container to debian:12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update Go container to debian 12 (bookworm) slim as base image
+  ([#347](https://github.com/pulumi/pulumi-docker-containers/pull/347))
+
 - Update aws-iam-authenticator to version 0.6.29
   ([#345](https://github.com/pulumi/pulumi-docker-containers/pull/345))
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -51,7 +51,7 @@ RUN case $(uname -m) in \
     go version
 
 # The runtime container
-FROM debian:11-slim
+FROM debian:12-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for go"
 WORKDIR /pulumi/projects
 


### PR DESCRIPTION
Missed this in https://github.com/pulumi/pulumi-docker-containers/pull/236, flagged by Snyk due to curl vulnerabilities
