### PR TITLE
Update for Poetry 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update Poetry config for the Poetry 2.0 release
+  ([#353](https://github.com/pulumi/pulumi-docker-containers/pull/353)
+
 ## 3.144.0
 
 - Update Go container to debian 12 (bookworm) slim as base image

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -145,9 +145,6 @@ RUN pyenv global 3.12 # Default version
 # Poetry
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local/share/pypoetry python3 -
 RUN ln -s /usr/local/share/pypoetry/bin/poetry /usr/local/bin/
-# Set poetry to prefer the active python version so it interacts nicely with pyenv, otherwise
-# poetry will create virtual environments using the python version used by poetry itself.
-RUN poetry config virtualenvs.prefer-active-python true
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | XDG_BIN_HOME=/usr/local/share/uv bash -s -- --no-modify-path
 RUN ln -s /usr/local/share/uv/uv /usr/local/bin/


### PR DESCRIPTION
With Poetry 2.0 `virtualenvs.prefer-active-python` has been replaced by the inverse setting `virtualenvs.use-poetry-python` and the former is now the default.

https://github.com/python-poetry/poetry/pull/9786
