### PR TITLE
Fix ci-ok

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,10 +554,12 @@ jobs:
   ci-ok:
     name: ci-ok
     needs: [kitchen-sink, provider-build-environment, base, debian-sdk, ubi-sdk]
-    if: always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded
-        run: exit 0
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi
+          exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
+      - name: Fail test
+        run: exit 1
       - name: Build
         run: |
           docker build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-      - name: Fail test
-        run: exit 1
       - name: Build
         run: |
           docker build \


### PR DESCRIPTION
The previous change in https://github.com/pulumi/pulumi-docker-containers/pull/381 just skipped ci-ok on failures, instead of making that step fail.

https://github.com/pulumi/pulumi-docker-containers/actions/runs/12913760708/job/36014304257 shows an example run with an intentional failure in one of the matrix jobs.