### PR TITLE
Update corepack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- Update corepack
+  ([391](https://github.com/pulumi/pulumi-docker-containers/pull/391))
+
 ## 3.147.0
 
 - Add ARM64 version of the kitchen sink and provider build environment images

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -162,7 +162,8 @@ RUN fnm install 18 && \
   fnm install 23 && \
   fnm alias 22 default
 ENV PATH=/usr/local/share/fnm/aliases/default/bin:$PATH
-RUN corepack install --global pnpm yarn
+RUN npm install -g corepack && \
+    corepack install -g pnpm yarn
 
 # Passing --build-arg PULUMI_VERSION=vX.Y.Z will use that version
 # of the SDK. Otherwise, we use whatever get.pulumi.com thinks is


### PR DESCRIPTION
The corepack version that is currently shipping with Node.js releases
fails to install the latest release of pnpm due to missing an updated
signature key.

Update the corepack version to the latest available.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/390