### PR TITLE
Update tools in build-environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#436](https://github.com/pulumi/pulumi-docker-containers/pull/436))
 - Drop .NET 6.0 from kitchen sink
   ([#437](https://github.com/pulumi/pulumi-docker-containers/pull/437))
+- Update tools in build-environment
+  ([#441](https://github.com/pulumi/pulumi-docker-containers/pull/441))
 
 ## 3.147.0
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -216,11 +216,11 @@ FROM base AS build-environment
 ARG TARGETARCH
 
 # https://github.com/pulumi/pulumictl/releases
-ENV PULUMICTL_VERSION 0.0.48
+ENV PULUMICTL_VERSION 0.0.49
 # https://github.com/golangci/golangci-lint/releases
-ENV GOLANGCI_LINT_VERSION 1.62.0
+ENV GOLANGCI_LINT_VERSION 1.64.8
 # https://github.com/goreleaser/goreleaser/releases
-ENV GORELEASER_VERSION 2.6.1
+ENV GORELEASER_VERSION 2.8.2
 
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Update pulumictl, golanglint-ci and goreleaser in the build-environment image
