### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: CI Build
 on:
   workflow_dispatch:
@@ -27,8 +28,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }} # Used by test-containers.sh\
   # The organization in the Pulumi SaaS service against which the integration
   # tests will run:
   PULUMI_ORG: "pulumi-test"
@@ -36,11 +35,6 @@ env:
   PULUMI_VERSION: ${{ github.event.inputs.pulumi_version || github.event.client_payload.ref }}
   # Do not depend on C library for the tests.
   CGO_ENABLED: "0"
-  # Azure credentials for the tests
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
   AWS_REGION: "us-west-2"
   # GCP
   GCP_SERVICE_ACCOUNT_EMAIL: "pulumi-ci@pulumi-ci-gcp-provider.iam.gserviceaccount.com"
@@ -50,12 +44,20 @@ env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: "pulumi-ci"
   GCP_REGION: "us-central1"
   GCP_ZONE: "us-central1-a"
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,ARM_CLIENT_ID,ARM_CLIENT_SECRET,ARM_TENANT_ID,ARM_SUBSCRIPTION_ID
 
 jobs:
   comment-notification:
     if: github.event_name == 'repository_dispatch' && github.event.client_payload.github.payload.issue.number
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Create URL to the run output
         id: vars
         run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
@@ -86,6 +88,9 @@ jobs:
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set version to latest
         if: ${{ !env.PULUMI_VERSION }}
         run: |
@@ -144,19 +149,17 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
-      # Note we use /src/pulumi-test-containers as entrypoint and not bash to avoid bash
-      # changing the environment in some way.
+        # Note we use /src/pulumi-test-containers as entrypoint and not bash to avoid bash
+        # changing the environment in some way.
         run: |
           set -exo pipefail
           chmod o+r $GOOGLE_APPLICATION_CREDENTIALS
@@ -220,6 +223,9 @@ jobs:
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set version to latest
         if: ${{ !env.PULUMI_VERSION }}
         run: |
@@ -264,14 +270,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -308,6 +312,9 @@ jobs:
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set version to latest
         if: ${{ !env.PULUMI_VERSION }}
         run: |
@@ -330,6 +337,9 @@ jobs:
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Define Matrix
         id: define-matrix
@@ -348,6 +358,9 @@ jobs:
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set version to latest
         if: ${{ !env.PULUMI_VERSION }}
         run: |
@@ -400,14 +413,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -442,6 +453,9 @@ jobs:
     outputs:
       matrix: ${{ steps.define-matrix-sdk-manifests.outputs.matrix }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Define Matrix for UBI SDK Manifests
         id: define-matrix-sdk-manifests
@@ -460,6 +474,9 @@ jobs:
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set version to latest
         if: ${{ !env.PULUMI_VERSION }}
         run: |
@@ -515,14 +532,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -557,6 +572,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: CI succeeded
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Release Build
 on:
   # Allow the workflow to be triggered manually, e.g. for testing, or after
@@ -26,9 +27,6 @@ on:
       - docker-build # Legacy event name, will delete once no longer used.
       - release-build # Current event name.
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-  # Used to run the container tests:
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   # The organization in the Pulumi SaaS service against which the integration
   # tests will run:
   PULUMI_ORG: "pulumi-test"
@@ -40,11 +38,6 @@ env:
   PULUMI_VERSION: ${{ github.event.inputs.pulumi_version || github.event.client_payload.ref }}
   # Do not depend on C library for the tests.
   CGO_ENABLED: "0"
-  # Azure credentials for the tests
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
   AWS_REGION: "us-west-2"
   # GCP
   GCP_SERVICE_ACCOUNT_EMAIL: "pulumi-ci@pulumi-ci-gcp-provider.iam.gserviceaccount.com"
@@ -54,6 +47,11 @@ env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: "pulumi-ci"
   GCP_REGION: "us-central1"
   GCP_ZONE: "us-central1-a"
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,ARM_CLIENT_ID,ARM_CLIENT_SECRET,ARM_TENANT_ID,ARM_SUBSCRIPTION_ID
 
 jobs:
   kitchen-sink:
@@ -70,6 +68,9 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -79,7 +80,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -121,14 +122,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -188,11 +187,14 @@ jobs:
     needs: ["kitchen-sink"]
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Versioned manifest
         run: |
           docker manifest create \
@@ -237,6 +239,9 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -246,7 +251,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -278,14 +283,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -319,11 +322,14 @@ jobs:
     needs: ["provider-build-environment"]
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Versioned manifest
         run: |
           docker manifest create \
@@ -350,12 +356,15 @@ jobs:
         os: ["debian", "ubi"]
         arch: ["arm64", "amd64"]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -378,11 +387,14 @@ jobs:
     needs: ["base"]
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Debian manifest
         run: |
           docker manifest create \
@@ -420,6 +432,9 @@ jobs:
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Define Matrix
         id: define-matrix
@@ -436,6 +451,9 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Set image name
         run: |
@@ -449,7 +467,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -490,14 +508,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -540,6 +556,9 @@ jobs:
     outputs:
       matrix: ${{ steps.define-matrix-sdk-manifests.outputs.matrix }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Define Matrix for SDK Manifests
         id: define-matrix-sdk-manifests
@@ -554,11 +573,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix-sdk-manifests.outputs.matrix) }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Debian manifest
         run: |
           docker manifest create \
@@ -615,6 +637,9 @@ jobs:
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Define Matrix for UBI SDK Manifests
         id: define-matrix
@@ -631,6 +656,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-ubi-matrix.outputs.matrix) }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set image name
         run: |
           echo "IMAGE_NAME=${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}${{ matrix.suffix }}:${{ env.PULUMI_VERSION }}-ubi" >> $GITHUB_ENV
@@ -644,7 +672,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -687,14 +715,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: pulumi-docker-containers@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL
-            }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GCP_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: Tests
@@ -731,7 +757,6 @@ jobs:
           docker tag ${{ env.IMAGE_NAME }} ${{ env.DEFAULT_IMAGE_NAME }}
           docker push ${{ env.DEFAULT_IMAGE_NAME }}
 
-
   start-syncs:
     name: Start syncs to other container registries
     needs: ["kitchen-sink", "base-manifests", "debian-sdk-manifests", "ubi-sdk"]
@@ -751,6 +776,9 @@ jobs:
     # workflows.
     if: ${{ github.event.inputs.force_release || github.event_name == 'repository_dispatch' }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Install Pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # Snyk scanning steps are marked continue-on-error because there are often
 # vulnerabilities that may have no possible remediation (e.g. glibc
 # vulnerabilities in the Debian base).  We want to be *informed* about the
@@ -12,6 +13,11 @@ env:
   DOCKER_ORG: pulumi
   DOCKER_USERNAME: pulumibot
   DISPATCH_REF: ${{ github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 
 jobs:
   kitchen-sink:
@@ -24,6 +30,9 @@ jobs:
         suffix: ["", "-nonroot"]
         arch: ["amd64", "arm64"]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -33,7 +42,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -41,7 +50,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_ORG }}/pulumi:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-${{ matrix.arch }}
           args: --severity-threshold=high --file=docker/pulumi/Dockerfile
@@ -61,6 +70,9 @@ jobs:
       matrix:
         arch: ["amd64", "arm64"]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -70,7 +82,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -78,7 +90,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_ORG }}/pulumi-provider-build-environment:${{ env.PULUMI_VERSION }}-${{ matrix.arch }}
           args: --severity-threshold=high --file=docker/pulumi/Dockerfile
@@ -99,12 +111,15 @@ jobs:
         os: ["debian", "ubi"]
         arch: ["arm64", "amd64"]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -112,7 +127,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_ORG }}/pulumi-base:${{ env.PULUMI_VERSION }}-${{ matrix.os }}-${{ matrix.arch }}
           args: --severity-threshold=high --file=docker/base/Dockerfile.${{ matrix.os }} --platform=linux/${{ matrix.arch }}
@@ -146,12 +161,15 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-debian-matrix.outputs.matrix) }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -162,7 +180,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_NAME }}
           args: --severity-threshold=high --file=docker/${{ matrix.sdk }}/Dockerfile.debian --platform=linux/amd64
@@ -180,7 +198,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_NAME }}
           args: --severity-threshold=high --file=docker/${{ matrix.sdk }}/Dockerfile.debian --platform=linux/arm64
@@ -201,12 +219,15 @@ jobs:
       matrix:
         sdk: ["nodejs", "python", "dotnet", "go"]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -214,7 +235,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_ORG }}/pulumi-${{ matrix.sdk }}:${{ env.PULUMI_VERSION }}-ubi
           args: --severity-threshold=high --file=docker/${{ matrix.sdk }}/Dockerfile.ubi --platform=linux/amd64

--- a/.github/workflows/sync-ecr.yml
+++ b/.github/workflows/sync-ecr.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # Copies all Pulumi Docker images for the supplied version from Docker Hub to
 # AWS ECR Public Gallery.
 name: Sync to ECR
@@ -20,6 +21,11 @@ on:
 env:
   DOCKER_USERNAME: pulumi
   PULUMI_VERSION: ${{ github.event.inputs.pulumi_version || github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 
 jobs:
   sync-to-ecr:
@@ -33,6 +39,9 @@ jobs:
           - suffix: -nonroot
             image: pulumi
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
@@ -42,7 +51,7 @@ jobs:
           role-duration-seconds: 3600
           role-external-id: upload-pulumi-release
           role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
       - name: Get Public ECR Authorization token
         run: |
           aws --region us-east-1 ecr-public get-authorization-token \
@@ -87,6 +96,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-debian-matrix.outputs.matrix) }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
@@ -96,22 +108,13 @@ jobs:
           role-duration-seconds: 3600
           role-external-id: upload-pulumi-release
           role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
       - name: Get Public ECR Authorization token
         run: |
           aws --region us-east-1 ecr-public get-authorization-token \
             --query 'authorizationData.authorizationToken' | \
             tr -d '"' | base64 --decode | cut -d: -f2 | \
             docker login -u AWS --password-stdin https://public.ecr.aws
-      # NOTE: The process we use for the Kichen Sink image, which is
-      # single-platform, will not work here.  Pulling a multi-arch manifest from
-      # Docker Hub, tagging, then pushing will only result in the image of the
-      # host's architecture (e.g. linux/amd64) getting pushed to the desintation repo.
-      # For more information, see: https://docs.docker.com/registry/spec/manifest-v2-2/
-      #
-      # Prior to re-creating the manifests, we must pull, tag, and push the
-      # consituent images in the manifests because manifests cannot use source
-      # images from a different registry.
       - name: Tag ${{ env.PULUMI_VERSION }}-debian-amd64 image and push to AWS Public ECR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}-debian-amd64
@@ -166,6 +169,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-ubi-matrix.outputs.matrix) }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
@@ -175,7 +181,7 @@ jobs:
           role-duration-seconds: 3600
           role-external-id: upload-pulumi-release
           role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
       - name: Get Public ECR Authorization token
         run: |
           aws --region us-east-1 ecr-public get-authorization-token \


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
