### PR TITLE
Fix docker login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -194,7 +194,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Versioned manifest
         run: |
           docker manifest create \
@@ -251,7 +251,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -329,7 +329,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Versioned manifest
         run: |
           docker manifest create \
@@ -364,7 +364,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -394,7 +394,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Debian manifest
         run: |
           docker manifest create \
@@ -467,7 +467,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -580,7 +580,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Debian manifest
         run: |
           docker manifest create \
@@ -672,7 +672,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -82,7 +82,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -119,7 +119,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -169,7 +169,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
@@ -227,7 +227,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_TOKEN }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
       - name: Set version
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi-docker-containers/pull/453

It looks like `DOCKER_HUB_TOKEN` is set on this repo as an actions secret. The ESC environment has a `DOCKER_HUB_PASSWORD` instead.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/466