### PR TITLE
Pin Gradle to 8.14.2 and Maven to 3.9.10 in the UBI Java image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+- Pin Gradle to 8.14.2 and Maven to 3.9.10 in the UBI Java image
+  ([#487](https://github.com/pulumi/pulumi-docker-containers/pull/487))
+
+## 3.175.0
+
 - Ensure we install Yarn classic
-  ([480](https://github.com/pulumi/pulumi-docker-containers/pull/480))
+  ([#480](https://github.com/pulumi/pulumi-docker-containers/pull/480))
 
 ## 3.171.0
 

--- a/docker/java/Dockerfile.ubi
+++ b/docker/java/Dockerfile.ubi
@@ -16,6 +16,9 @@ FROM redhat/ubi9-minimal:latest
 LABEL org.opencontainers.image.description="Pulumi CLI container for Java"
 WORKDIR /pulumi/projects
 
+ENV MAVEN_VERSION 3.9.10
+ENV GRADLE_VERSION 8.14.2
+
 RUN microdnf install -y \
     git \
     tar \
@@ -29,8 +32,8 @@ RUN microdnf install -y \
 
 RUN curl -fsSL "https://get.sdkman.io" | bash \
     && bash -c ". /root/.sdkman/bin/sdkman-init.sh \
-        && sdk install maven \
-        && sdk install gradle \
+        && sdk install maven ${MAVEN_VERSION} \
+        && sdk install gradle ${GRADLE_VERSION} \
         && sdk flush archives \
         && sdk flush temp \
         "


### PR DESCRIPTION
For the UBI image we use [SDKMAN!](https://sdkman.io) to install gradle and maven.

Due to https://github.com/sdkman/sdkman-cli/issues/1458 we have to explicitly ask for Maven 3.9.10, otherwise 3.9.9 will be installed. Pin Gradle to the latest version while we are at it. This better matches the behaviour of the Debian based images, which install a predictable version (what’s in the repo).
