### PR TITLE
UBI images: upgrade base system

### DIFF
--- a/docker/base/Dockerfile.ubi
+++ b/docker/base/Dockerfile.ubi
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 FROM redhat/ubi9-minimal:latest as builder
 ARG PULUMI_VERSION
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
   make \
   gcc \
   git \
@@ -17,7 +17,7 @@ LABEL org.opencontainers.image.description="Pulumi CLI container, bring your own
 WORKDIR /pulumi
 COPY --from=builder /root/.pulumi/bin bin
 
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
   git \
   tar \
   ca-certificates

--- a/docker/dotnet/Dockerfile.ubi
+++ b/docker/dotnet/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 FROM redhat/ubi9-minimal:latest as builder
 ARG PULUMI_VERSION
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     gzip \
     tar
 # Install the Pulumi SDK, including the CLI and language runtimes.
@@ -14,7 +14,7 @@ ARG LANGUAGE_VERSION
 LABEL org.opencontainers.image.description="Pulumi CLI container for dotnet"
 WORKDIR /pulumi/projects
 
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     ca-certificates \
     # Required by the dotnet-install script, which calls `find`:
     findutils \

--- a/docker/go/Dockerfile.ubi
+++ b/docker/go/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 FROM redhat/ubi9-minimal:latest as builder
 ARG PULUMI_VERSION
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     gzip \
     tar
 # Install the Pulumi SDK, including the CLI and language runtimes.
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.description="Pulumi CLI container for go"
 WORKDIR /pulumi/projects
 
 # Install needed tools, like git
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     git \
     tar \
     ca-certificates; \

--- a/docker/java/Dockerfile.ubi
+++ b/docker/java/Dockerfile.ubi
@@ -3,7 +3,7 @@
 # Must be defined first
 FROM redhat/ubi9-minimal:latest as builder
 ARG PULUMI_VERSION
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     git \
     tar \
     unzip
@@ -19,7 +19,7 @@ WORKDIR /pulumi/projects
 ENV MAVEN_VERSION 3.9.10
 ENV GRADLE_VERSION 8.14.2
 
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     git \
     tar \
     java-21-openjdk-devel \

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 FROM redhat/ubi9-minimal:latest as builder
 ARG PULUMI_VERSION
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     gzip \
     tar
 # Install the Pulumi SDK, including the CLI and language runtimes.
@@ -14,7 +14,7 @@ ARG LANGUAGE_VERSION
 LABEL org.opencontainers.image.description="Pulumi CLI container for nodejs"
 WORKDIR /pulumi/projects
 
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     ca-certificates \
     git \
     tar \

--- a/docker/python/Dockerfile.ubi
+++ b/docker/python/Dockerfile.ubi
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 FROM redhat/ubi9-minimal:latest as builder
 ARG PULUMI_VERSION
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     gzip \
     tar
 # Install the Pulumi SDK, including the CLI and language runtimes.
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.description="Pulumi CLI container for python"
 WORKDIR /pulumi/projects
 
 # Install needed tools, like git, and build dependencies
-RUN microdnf install -y \
+RUN microdnf upgrade -y && microdnf install -y \
     bzip2 \
     bzip2-devel \
     ca-certificates \


### PR DESCRIPTION
Run `microdnf upgrade` to make ensure that the base system packages are udpated to the latest versions.
