### PR TITLE
Update debian images to trixie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update debian based images to Debian Trixie (13)
+
+## 3.192.0
+
 - Provider Build Environment image: Update golangci-lint to v2
  ([#515](https://github.com/pulumi/pulumi-docker-containers/pull/515))
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The base and SDK-specific images are considerably smaller than the combined `pul
 
 ## Build Matrix
 
-`pulumi/pulumi` is built for amd64 and arm64, using Debian Bookworm (12) as the base image.
+`pulumi/pulumi` is built for amd64 and arm64, using Debian Trixie (13) as the base image.
 
 Each of the other images described above are built on a matrix of the following base images and platforms:
 
-- [debian/debian:12-slim](https://github.com/debuerreotype/docker-debian-artifacts/blob/d99a48edaa18ad2bbb260c388b274c8c093f2d32/bullseye/slim/Dockerfile), (AKA "bookworm") tagged with the following suffixes:
+- [debian/debian:13-slim](https://hub.docker.com/layers/library/debian/trixie-slim/images/sha256-5298f9fed4596ad58f2c926c93bfbd7fe54b3f34637b85b3e5393efc1876b66a), (AKA "trixie") tagged with the following suffixes:
   - `-debian-amd64`: Image manifest for the `linux/amd64` platform.
   - `-debian-arm64`: Image manifest for the `linux/arm64` platform.
   - `-debian`:  Manifest list of `-debian-amd64` and `-debian-arm64`.  Executing `docker pull` against this tag will grab the appropriate image for the supported platform you are currently running, and thus should be the default choice.

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 ARG PULUMI_VERSION
 RUN apt-get update -y && \
   apt-get upgrade -y && \
@@ -13,7 +13,7 @@ RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
 # This is our base container, so let's copy all the runtimes to .pulumi/bin
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container, bring your own SDK"
 WORKDIR /pulumi
 COPY --from=builder /root/.pulumi/bin bin

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 ARG PULUMI_VERSION
 RUN apt-get update -y && \
     apt-get upgrade -y && \
@@ -14,7 +14,7 @@ RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 
 # The runtime container
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for dotnet"
 WORKDIR /pulumi/projects
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -51,7 +51,7 @@ RUN case $(uname -m) in \
     go version
 
 # The runtime container
-FROM debian:12-slim
+FROM debian:trixie-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for go"
 WORKDIR /pulumi/projects
 

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 # Interim container so we can copy pulumi binaries
 # Must be defined first
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 ARG PULUMI_VERSION
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -12,7 +12,7 @@ RUN apt-get update -y && \
 RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for java"
 WORKDIR /pulumi/projects
 

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -3,7 +3,7 @@
 # Must be defined first
 ARG LANGUAGE_VERSION
 
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 ARG PULUMI_VERSION
 RUN apt-get update -y && \
     apt-get upgrade -y && \
@@ -17,7 +17,7 @@ RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 
 # The runtime container
-FROM node:${LANGUAGE_VERSION}-bookworm-slim
+FROM node:${LANGUAGE_VERSION}-trixie-slim
 LABEL org.opencontainers.image.description="Pulumi CLI container for nodejs"
 WORKDIR /pulumi/projects
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.24-bookworm as builder
+FROM golang:1.24-trixie as builder
 
 RUN go install sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator@v0.7.4
 
-FROM debian:12 AS base
+FROM debian:trixie AS base
 
 # These values are passed in by the build system automatically. The options are: arm64, amd64
 # See: https://docs.docker.com/build/building/variables/#pre-defined-build-arguments

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -3,7 +3,7 @@
 # Must be defined first
 ARG LANGUAGE_VERSION
 
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 ARG PULUMI_VERSION
 RUN apt-get update -y && \
     apt-get upgrade -y && \
@@ -16,7 +16,7 @@ RUN apt-get update -y && \
 RUN curl -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION
 
 # The runtime container
-FROM python:${LANGUAGE_VERSION}-slim-bookworm
+FROM python:${LANGUAGE_VERSION}-slim-trixie
 LABEL org.opencontainers.image.description="Pulumi CLI container for python"
 WORKDIR /pulumi/projects
 


### PR DESCRIPTION
Debian 13 “trixie” was released last month https://www.debian.org/News/2025/20250809
