### PR TITLE
Reclaim disk space before amd64 pull/push

### DIFF
--- a/.github/workflows/sync-ghcr.yml
+++ b/.github/workflows/sync-ghcr.yml
@@ -46,6 +46,16 @@ jobs:
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
           docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
           docker push ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      - name: Reclaim disk before amd64 pull/push
+        run: |
+          set -euxo pipefail
+          df -h
+          docker image rm -f \
+            docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 \
+            ghcr.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 \
+            || true
+          docker system prune -af --volumes || true
+          df -h
       - name: Tag ${{ env.PULUMI_VERSION }}-amd64 and push to GHCR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64


### PR DESCRIPTION
The sync-ghcr.yml workflow is failing during the amd64 push to GHCR, running out of disk space on the runner.

To address, reclaim disk space after the arm64 step and before the amd64 step. Let's see if this helps.

Fixes #602