### PR TITLE
sync-ecr -- Reclaim disk space before amd64 pull/push

### DIFF
--- a/.github/workflows/sync-ecr.yml
+++ b/.github/workflows/sync-ecr.yml
@@ -65,6 +65,16 @@ jobs:
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
           docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
           docker push public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64
+      - name: Reclaim disk before amd64 pull/push
+        run: |
+          set -euxo pipefail
+          df -h
+          docker image rm -f \
+            docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 \
+            public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-arm64 \
+            || true
+          docker system prune -af --volumes || true
+          df -h
       - name: Tag ${{ env.PULUMI_VERSION }}-amd64 and push to AWS Public ECR
         run: |
           docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ matrix.image }}:${{ env.PULUMI_VERSION }}${{ matrix.suffix }}-amd64


### PR DESCRIPTION
https://github.com/pulumi/pulumi-docker-containers/issues/612

sync-ecr is running out of space.  reclaim disk space after the arm64 step and before the amd64 step. This same fix was appled to sync-ghcr