### PR TITLE
Limit concurrency in sync-{ecr,ghcr} jobs

### DIFF
--- a/.github/workflows/sync-ecr.yml
+++ b/.github/workflows/sync-ecr.yml
@@ -32,6 +32,8 @@ jobs:
     name: Kitchen Sink images
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - image: pulumi-provider-build-environment
@@ -113,6 +115,7 @@ jobs:
     needs: define-debian-matrix
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.define-debian-matrix.outputs.matrix) }}
     steps:
       - name: Fetch secrets from ESC
@@ -186,6 +189,7 @@ jobs:
     needs: define-ubi-matrix
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.define-ubi-matrix.outputs.matrix) }}
     steps:
       - name: Fetch secrets from ESC

--- a/.github/workflows/sync-ghcr.yml
+++ b/.github/workflows/sync-ghcr.yml
@@ -26,6 +26,8 @@ jobs:
     name: Kitchen Sink images
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - image: pulumi-provider-build-environment
@@ -94,6 +96,7 @@ jobs:
     needs: define-debian-matrix
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.define-debian-matrix.outputs.matrix) }}
     steps:
       # Pulling a multi-arch manifest from Docker Hub, tagging, then pushing
@@ -161,6 +164,7 @@ jobs:
     needs: define-ubi-matrix
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.define-ubi-matrix.outputs.matrix) }}
     steps:
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
We often get rate limit errors when syncing images, for example https://github.com/pulumi/pulumi-docker-containers/actions/runs/20676025835/job/59363800256

These jobs run in the background on release, and are not on any sort of development path, so it's fine for these to run slower, but more reliably.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/577
Fixes https://github.com/pulumi/pulumi-docker-containers/issues/628