### PR TITLE
Use arm images to build the base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,11 +272,17 @@ jobs:
 
   base:
     name: Base image
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         os: ["debian", "ubi"]
+        arch: ["arm64", "amd64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       # If no version of Pulumi is supplied by the incoming event (e.g. in the
       # case of a PR or merge to main), we use the latest production version:
@@ -296,7 +302,7 @@ jobs:
         run: |
           docker build \
             -f docker/base/Dockerfile.${{ matrix.os }} \
-            --platform linux/arm64,linux/amd64 \
+            --platform linux/${{ matrix.arch }} \
             . \
             -t ${{ env.DOCKER_ORG }}/pulumi-base:${{ env.PULUMI_VERSION }}-${{ matrix.os }} \
             --build-arg PULUMI_VERSION=${{ env.PULUMI_VERSION }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,12 +352,17 @@ jobs:
 
   base:
     name: Base image
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         os: ["debian", "ubi"]
         arch: ["arm64", "amd64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets


### PR DESCRIPTION
When ARM runners for OSS projects got released, we switched builds for ARM images to use these, but we missed updating the base image.

This will hopefully fix the issue seen in https://github.com/pulumi/pulumi-docker-containers/issues/631
