### PR TITLE
Remove policy shims from Dockerfiles

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -70,7 +70,6 @@ COPY --from=builder /golang/go /usr/local
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/pulumi-language-go /pulumi/bin/pulumi-language-go
-COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/pulumi-analyzer-policy
 ENV GOPATH=/go
 ENV CGO_ENABLED=0
 ENV PATH "/pulumi/bin:${GOPATH}/bin:${PATH}"

--- a/docker/go/Dockerfile.ubi
+++ b/docker/go/Dockerfile.ubi
@@ -38,7 +38,6 @@ COPY --from=builder /golang/go /usr/local
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/pulumi-language-go /pulumi/bin/pulumi-language-go
-COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/pulumi-analyzer-policy
 ENV GOPATH=/go
 ENV CGO_ENABLED=0
 ENV PATH "/pulumi/bin:${GOPATH}/bin:${PATH}"

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update -y && \
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-java* /pulumi/bin/
-COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/java/Dockerfile.ubi
+++ b/docker/java/Dockerfile.ubi
@@ -41,7 +41,6 @@ RUN curl -fsSL "https://get.sdkman.io" | bash \
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-java* /pulumi/bin/
-COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 
 ENV PATH="/pulumi/bin:/root/.sdkman/candidates/maven/current/bin:/root/.sdkman/candidates/gradle/current/bin:${PATH}" \
     JAVA_HOME="/usr/lib/jvm/jre-21-openjdk" \

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get update -y && \
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
-COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -34,7 +34,6 @@ RUN npm install -g corepack bun && \
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
-COPY --from=builder /root/.pulumi/bin/pulumi-analyzer-policy /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]


### PR DESCRIPTION
Pulumi v3.221.0 no longer includes policy shims, so remove these from the Dockerfiles.

Fixes #649