### PR TITLE
allow release process to continue if snyk scan fails

### DIFF
--- a/.github/scripts/filter-sarif.py
+++ b/.github/scripts/filter-sarif.py
@@ -15,6 +15,17 @@ import sys
 MAX_RUNS = 20
 MAX_CHUNKS = 2
 
+if not os.path.exists("snyk.sarif"):
+    print("snyk.sarif not found — Snyk scan likely failed. Writing empty SARIF.")
+    empty = {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{"tool": {"driver": {"name": "SnykContainer", "rules": []}}, "results": []}],
+    }
+    with open("out_0.sarif", "w") as out:
+        json.dump(empty, out, indent=2)
+    sys.exit(0)
+
 with open("snyk.sarif") as f:
     sarif = json.load(f)
 

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           [ -z "${{ env.DISPATCH_REF }}" ] && echo "PULUMI_VERSION=$(curl https://www.pulumi.com/latest-version)" >> $GITHUB_ENV || echo "PULUMI_VERSION=${{ env.DISPATCH_REF }}" >> $GITHUB_ENV
       - name: Snyk scan
-        continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ steps.esc-secrets.outputs.SNYK_TOKEN }}


### PR DESCRIPTION
Snyk scans are sadly incredibly flaky.  This means release processes often fail because we can' tfind the sarif file.  Instead always create a sarif file, but still fail the snyk scan (remove the continue-on-error there) so we can notice issues with snyk (no idea what to do about them, but at least we know)