### PR TITLE
Add pulumi-language-bun to nodejs images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Include `pulumi-language-bun` in the nodejs images so the Bun language runtime
+  can be used out of the box.
+  ([#709](https://github.com/pulumi/pulumi-docker-containers/issues/709))
+
 - Add Node.js 26 and drop 20
   ([#703](https://github.com/pulumi/pulumi-docker-containers/pull/703))
 

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update -y && \
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi-language-bun /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/docker/nodejs/Dockerfile.ubi
+++ b/docker/nodejs/Dockerfile.ubi
@@ -34,6 +34,7 @@ RUN npm install -g corepack bun && \
 # Uses the workdir, copies from pulumi interim container
 COPY --from=builder /root/.pulumi/bin/pulumi /pulumi/bin/pulumi
 COPY --from=builder /root/.pulumi/bin/*-nodejs* /pulumi/bin/
+COPY --from=builder /root/.pulumi/bin/pulumi-language-bun /pulumi/bin/
 ENV PATH "/pulumi/bin:${PATH}"
 
 CMD ["pulumi"]

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -212,6 +212,7 @@ func TestBunRuntime(t *testing.T) {
 	p := filepath.Join("testdata", "node-bun")
 	copyTestData(t, p)
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel:  true, // ProgramTest calls t.Parallel itself; we already did above.
 		Dir:         p,
 		Quick:       true,
 		SkipRefresh: true,

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -172,6 +172,11 @@ func TestKitchenSinkLanguageVersions(t *testing.T) {
 				// The `node-default` test is run first, so we skip it here.
 				t.Skip()
 			}
+			if dir.Name() == "node-bun" {
+				// The `node-bun` test is covered by TestBunRuntime, which runs on
+				// every container that has nodejs (including the kitchen sink).
+				t.Skip()
+			}
 			p := filepath.Join("testdata", dir.Name())
 			copyTestData(t, p)
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -193,6 +198,33 @@ func TestKitchenSinkLanguageVersions(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestBunRuntime verifies that a Pulumi program using the bun language runtime
+// can be installed and previewed on any container that ships nodejs. Regression
+// test for https://github.com/pulumi/pulumi-docker-containers/issues/709.
+func TestBunRuntime(t *testing.T) {
+	if !hasNodejs(t) {
+		t.Skip("Skipping test for images without nodejs")
+	}
+	t.Parallel()
+
+	p := filepath.Join("testdata", "node-bun")
+	copyTestData(t, p)
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         p,
+		Quick:       true,
+		SkipRefresh: true,
+		PrepareProject: func(info *engine.Projinfo) error {
+			cmd := exec.Command("pulumi", "install")
+			cmd.Dir = info.Root
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Logf("install failed: %s: %s", err, out)
+			}
+			return err
+		},
+	})
 }
 
 func TestCLIToolTests(t *testing.T) {

--- a/tests/testdata/node-bun/Pulumi.yaml
+++ b/tests/testdata/node-bun/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: node-bun
+runtime: bun
+description: A minimal Bun Pulumi program

--- a/tests/testdata/node-bun/index.ts
+++ b/tests/testdata/node-bun/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+
+if (typeof Bun === "undefined") {
+  throw new Error("Expected to be running under the Bun runtime");
+}

--- a/tests/testdata/node-bun/package.json
+++ b/tests/testdata/node-bun/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "node-bun",
+    "main": "index.ts",
+    "type": "module",
+    "devDependencies": {
+        "@types/bun": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.226.0"
+    },
+    "peerDependencies": {
+        "typescript": "^5"
+    }
+}

--- a/tests/testdata/node-bun/tsconfig.json
+++ b/tests/testdata/node-bun/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "ESNext"
+        ],
+        "target": "ESNext",
+        "module": "Preserve",
+        "moduleDetection": "force",
+        "jsx": "react-jsx",
+        "allowJs": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "verbatimModuleSyntax": true,
+        "noEmit": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noImplicitOverride": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noPropertyAccessFromIndexSignature": false
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
## Summary

- Copy `pulumi-language-bun` into both `docker/nodejs/Dockerfile` and `docker/nodejs/Dockerfile.ubi`. The existing `*-nodejs*` glob picks up `pulumi-language-nodejs` and `pulumi-resource-pulumi-nodejs` but missed the bun plugin, so a program with `runtime: bun` could not run on these images even though the `bun` CLI itself was installed.
- Add `tests/testdata/node-bun/` — a minimal Pulumi program declaring `runtime: bun` and asserting it is executing under Bun.
- Add `TestBunRuntime` in `tests/containers_test.go`, which previews the bun program on every image that ships nodejs (the dedicated nodejs images and the kitchen sink). `TestKitchenSinkLanguageVersions` skips `node-bun` since the dedicated test already exercises it there.

Fixes #709.

## Test plan

- [ ] CI builds the nodejs and kitchen-sink images and `TestBunRuntime` passes against both Debian and UBI variants.