### PR TITLE
Enable corepack across all Node.js versions in the kitchen-sink image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fix corepack
+  ([#725](https://github.com/pulumi/pulumi-docker-containers/pull/725))
+
+## 3.234
+
 - Include `pulumi-language-bun` in the nodejs images so the Bun language runtime
   can be used out of the box.
   ([#709](https://github.com/pulumi/pulumi-docker-containers/issues/709))

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -151,8 +151,11 @@ RUN fnm install 22 && \
   fnm install 26 && \
   fnm alias 26 default
 ENV PATH=/usr/local/share/fnm/aliases/default/bin:$PATH
-RUN npm install -g corepack bun && \
-    corepack install -g pnpm@^10 yarn@1
+RUN npm install -g corepack bun
+RUN for bin in /usr/local/share/fnm/node-versions/*/installation/bin; do \
+      "$bin/node" "$bin/corepack" enable --install-directory "$bin"; \
+    done
+RUN corepack install -g pnpm@^10 yarn@1
 
 # Passing --build-arg PULUMI_VERSION=vX.Y.Z will use that version
 # of the SDK. Otherwise, we use whatever get.pulumi.com thinks is

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -177,6 +177,11 @@ func TestKitchenSinkLanguageVersions(t *testing.T) {
 				// every container that has nodejs (including the kitchen sink).
 				t.Skip()
 			}
+			if dir.Name() == "node-corepack" {
+				// The `node-corepack` test is covered by TestCorepack, which exercises
+				// corepack across every node version the image ships.
+				t.Skip()
+			}
 			p := filepath.Join("testdata", dir.Name())
 			copyTestData(t, p)
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -226,6 +231,58 @@ func TestBunRuntime(t *testing.T) {
 			return err
 		},
 	})
+}
+
+func TestCorepack(t *testing.T) {
+	if !hasNodejs(t) {
+		t.Skip("Skipping test for images without nodejs")
+	}
+	t.Parallel()
+
+	// The kitchen sink ships multiple node versions via fnm; corepack must work on
+	// each of them. Other nodejs images ship a single version, so we test the
+	// default. An empty version means "use the image default, don't switch".
+	versions := []string{""}
+	if isKitchenSink(t) {
+		versions = []string{"22", "24", "26"}
+	}
+
+	for _, version := range versions {
+		version := version
+		name := "default"
+		if version != "" {
+			name = "node-" + version
+		}
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join("testdata", "node-corepack")
+			copyTestData(t, p)
+			if version != "" {
+				nodeVersion := filepath.Join(p, ".node-version")
+				require.NoError(t, os.WriteFile(nodeVersion, []byte(version+"\n"), os.ModePerm))
+			}
+			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				// We can't run the node tests in parallel because setting the node
+				// version is global for the container.
+				NoParallel:  true,
+				Dir:         p,
+				Quick:       true,
+				SkipRefresh: true,
+				PrepareProject: func(info *engine.Projinfo) error {
+					args := []string{"install"}
+					if version != "" {
+						args = append(args, "--use-language-version-tools")
+					}
+					cmd := exec.Command("pulumi", args...)
+					cmd.Dir = info.Root
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						t.Logf("install failed: %s: %s", err, out)
+					}
+					return err
+				},
+			})
+		})
+	}
 }
 
 func TestCLIToolTests(t *testing.T) {

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -237,7 +237,11 @@ func TestCorepack(t *testing.T) {
 	if !hasNodejs(t) {
 		t.Skip("Skipping test for images without nodejs")
 	}
-	t.Parallel()
+	// Intentionally NOT parallel. On the kitchen sink this switches the container's
+	// global node version (via --use-language-version-tools), so running concurrently
+	// would corrupt the other node-version-dependent tests (TestKitchenSinkLanguageVersions,
+	// TestBunRuntime) and vice versa. Staying serial keeps it isolated and leaves the
+	// default version active when it finishes.
 
 	// The kitchen sink ships multiple node versions via fnm; corepack must work on
 	// each of them. Other nodejs images ship a single version, so we test the

--- a/tests/testdata/node-corepack/Pulumi.yaml
+++ b/tests/testdata/node-corepack/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: node-corepack
+runtime:
+  name: nodejs
+  options:
+    packagemanager: pnpm
+description: Verifies corepack is enabled and honors the packageManager field in package.json

--- a/tests/testdata/node-corepack/index.ts
+++ b/tests/testdata/node-corepack/index.ts
@@ -1,0 +1,16 @@
+import { execSync } from "node:child_process";
+
+// The image's global pnpm is the latest 10.x. Corepack's shim, when enabled,
+// instead reads the `packageManager` field in package.json and runs that exact
+// version. Observing the pinned 9.x below is proof that corepack is active for the
+// current node version, not just that `pnpm` exists.
+const expected = "9.15.0";
+
+const actual = execSync("pnpm --version").toString().trim();
+
+if (actual !== expected) {
+  throw new Error(
+    `Expected corepack-managed pnpm ${expected}, got ${actual}. ` +
+      `Is corepack enabled for this node version?`,
+  );
+}

--- a/tests/testdata/node-corepack/package.json
+++ b/tests/testdata/node-corepack/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "node-corepack",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "packageManager": "pnpm@9.15.0"
+}

--- a/tests/testdata/node-corepack/tsconfig.json
+++ b/tests/testdata/node-corepack/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-docker-containers/pull/703 we dropped the `FNM_COREPACK_ENABLED` flag because Node.js 26 does not ship with corepack anymore. We do install corepack globally, however we missed that we need to call `corepack enable`. Do that.
