### PR TITLE
Install aws-iam-authenticator from release binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fix corepack
   ([#725](https://github.com/pulumi/pulumi-docker-containers/pull/725))
 
+- Update `aws-iam-authenticator` to v0.7.17 in the `pulumi` image, and install
+  it from the upstream release binaries instead of `go install` since newer
+  releases can no longer be installed that way.
+  ([#681](https://github.com/pulumi/pulumi-docker-containers/pull/681))
+
 ## 3.234
 
 - Include `pulumi-language-bun` in the nodejs images so the Bun language runtime

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -1,7 +1,3 @@
-FROM golang:1.26-trixie as builder
-
-RUN go install sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator@v0.7.4
-
 FROM debian:trixie AS base
 
 # These values are passed in by the build system automatically. The options are: arm64, amd64
@@ -16,6 +12,9 @@ LABEL org.opencontainers.image.description="The Pulumi CLI, in a Docker containe
 ENV GOLANG_VERSION 1.26.0
 ENV GOLANG_AMD64_SHA256 aac1b08a0fb0c4e0a7c1555beb7b59180b05dfc5a3d62e40e9de90cd42f88235
 ENV GOLANG_ARM64_SHA256 bd03b743eb6eb4193ea3c3fd3956546bf0e3ca5b7076c8226334afe6b75704cd
+
+# renovate: datasource=github-releases depName=kubernetes-sigs/aws-iam-authenticator
+ENV AWS_IAM_AUTHENTICATOR_VERSION v0.7.17
 
 # Install base dependencies
 RUN apt-get update -y && \
@@ -44,7 +43,6 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/*
 
 # Install cloud tools
-COPY --from=builder /go/bin/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 RUN \
   # Setup environment variables for architecture-specific packages
   if [ "$TARGETARCH" = "arm64" ]; then \
@@ -52,6 +50,15 @@ RUN \
   else \
     AWSCLI_ARCH=x86_64; \
   fi && \
+  # aws-iam-authenticator, verified against the checksums published with the release
+  AUTHENTICATOR_FILE="aws-iam-authenticator_${AWS_IAM_AUTHENTICATOR_VERSION#v}_linux_${TARGETARCH}" && \
+  AUTHENTICATOR_BASE_URL="https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${AWS_IAM_AUTHENTICATOR_VERSION}" && \
+  curl --proto "=https" --tlsv1.2 --fail --location --remote-name "${AUTHENTICATOR_BASE_URL}/${AUTHENTICATOR_FILE}" && \
+  curl --proto "=https" --tlsv1.2 --fail --location --silent --show-error \
+    "${AUTHENTICATOR_BASE_URL}/authenticator_${AWS_IAM_AUTHENTICATOR_VERSION#v}_checksums.txt" \
+    | grep " ${AUTHENTICATOR_FILE}\$" | sha256sum --check - && \
+  install --mode 755 "${AUTHENTICATOR_FILE}" /usr/bin/aws-iam-authenticator && \
+  rm "${AUTHENTICATOR_FILE}" && \
   # AWS v2 cli
   curl "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" -o "awscliv2.zip" && \
   unzip awscliv2.zip && \


### PR DESCRIPTION
## Summary

`aws-iam-authenticator` v0.7.12 and newer cannot be installed with `go install` because their `go.mod` contains a `replace` directive, which `go install pkg@version` rejects:

```
The go.mod file for the module providing named packages contains one or
more replace directives. It must not contain directives that would cause
it to be interpreted differently than if it were the main module.
```

This blocked Renovate's update to v0.7.17 and would block every future update.

Instead, download the official release binary from GitHub releases and verify it against the checksums file published alongside the release. The version is tracked with the repo's existing Renovate inline-comment convention (`github-releases` datasource), so future updates continue to arrive automatically and remain self-verifying without manual checksum edits. The golang builder stage, which existed only to build this binary, is dropped.

Closes #681

## Testing

Built a minimal `debian:trixie` image with the new `RUN` snippet for both `linux/amd64` and `linux/arm64`: the checksum verification passes (`aws-iam-authenticator_0.7.17_linux_amd64: OK`) and the installed binary reports `{"Version":"0.7.17"}`. The existing container test (`aws-iam-authenticator token`) covers it in CI.

Also verified the new `ENV` line is matched by the custom Renovate regex manager in `renovate.json5`:

```json
{"datasource":"github-releases","depName":"kubernetes-sigs/aws-iam-authenticator","currentValue":"v0.7.17"}
```