### PR TITLE
Fix the two most common CI test flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi${{ matrix.variant }} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -252,6 +253,7 @@ jobs:
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -403,6 +405,7 @@ jobs:
             -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -522,6 +525,7 @@ jobs:
             -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -163,6 +164,7 @@ jobs:
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi-nonroot \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -300,6 +302,7 @@ jobs:
             -e RUN_CONTAINER_TESTS=true \
             -e IMAGE_VARIANT=pulumi \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -532,6 +535,7 @@ jobs:
             -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
@@ -739,6 +743,7 @@ jobs:
             -e LANGUAGE_VERSION=${{ matrix.language_version }} \
             -e SDKS_TO_TEST=${SDKS_TO_TEST} \
             -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e PULUMI_ORG=${PULUMI_ORG} \
             -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
             -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -106,6 +106,14 @@ func TestPulumiTemplateTests(t *testing.T) {
 		// globally shared S3 namespace, so creates can fail with BucketAlreadyExists.
 		// Retrying generates a fresh name. https://github.com/pulumi/pulumi-docker-containers/issues/737
 		RetryFailedSteps: true,
+		// The aws-* and gcp-* templates name their bucket `my-bucket`, and S3/GCS bucket
+		// names are global across all accounts. The default 7-hex-char auto-name suffix
+		// collides with other users of these templates; widen it to 12. Azure is left on
+		// default naming because storage accounts forbid hyphens and cap names at 24 chars.
+		OrderedConfig: []integration.ConfigValue{
+			{Key: "pulumi:autonaming.providers.aws.pattern", Value: "${name}-${hex(12)}", Path: true},
+			{Key: "pulumi:autonaming.providers.gcp.pattern", Value: "${name}-${hex(12)}", Path: true},
+		},
 	}
 
 	for _, test := range testCases {

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -102,6 +102,10 @@ func TestPulumiTemplateTests(t *testing.T) {
 		Quick:                true,
 		SkipRefresh:          true,
 		NoParallel:           true, // we mark tests as Parallel manually when instantiating
+		// The aws-* templates create a bucket whose auto-named suffix draws from the
+		// globally shared S3 namespace, so creates can fail with BucketAlreadyExists.
+		// Retrying generates a fresh name. https://github.com/pulumi/pulumi-docker-containers/issues/737
+		RetryFailedSteps: true,
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
## Summary

An audit of the last 50 merged PRs found that 18 (36%) needed a manual rerun of the CI Build workflow before merging. The two largest classifiable causes are fixed here:

**S3 `BucketAlreadyExists` in template tests (4 PRs: #715, #710, #703, #676).** The `aws-*` and `gcp-*` templates create a bucket with logical name `my-bucket`; auto-naming appends only a 7-hex-char suffix (28 bits), and the S3/GCS namespaces are shared globally with every other Pulumi user deploying these templates. Two layers of defense:
- `pulumi:autonaming` stack config widens the suffix to 12 hex chars (48 bits) for AWS and GCP resources, making collisions effectively impossible. Scoped per provider because Azure storage accounts forbid hyphens and cap names at 24 chars; Azure stays on default naming.
- `RetryFailedSteps: true` retries failed updates/refreshes/destroys up to 3 times with a fresh auto-name per attempt. This also covers transient cloud errors during destroy (e.g. the GCP bucket delete flake in #701).

Fixes #737.

**GitHub API rate limiting on plugin downloads (3 PRs: #707, #689, #670).** The test `docker run` invocations pass cloud credentials but not `GITHUB_TOKEN`, so the Pulumi CLI inside the container fetches plugins from `api.github.com` anonymously and trips the 60 req/hr/IP limit on shared runner IPs. Fixed by passing `-e GITHUB_TOKEN` (already in the workflow env via the ESC export) into all 9 test containers across `ci.yml` and `release.yml`. Fixes #738.

## Testing

- `go vet` and the CI cross-compile (`GOOS=linux GOARCH=amd64 go test -c`) pass on the test package.
- `actionlint` output is byte-identical before and after the workflow edits (no new findings).
- The autonaming config was verified locally end-to-end: `pulumi preview` against an `aws:s3:Bucket` with the provider-scoped pattern plans `my-bucket-402703e3fdf6`.
- The retry behavior and full template flow are exercised by this PR's CI run.