### PR TITLE
add .NET 10 container

### DIFF
--- a/.github/scripts/matrix/versions.py
+++ b/.github/scripts/matrix/versions.py
@@ -16,6 +16,6 @@ versioned = {
     },
     "dotnet": {
         "default": "8.0",
-        "additional": ["9.0"]
+        "additional": ["9.0", "10.0"]
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a .NET10.0 container([#743](https://github.com/pulumi/pulumi-docker-containers/pull/743))
+
 - Fix corepack
   ([#725](https://github.com/pulumi/pulumi-docker-containers/pull/725))
 


### PR DESCRIPTION
Currently the highest version of .NET containers is 9.0, even though the 10.0 LTS is out for quite a while already.  Add 10.0 to the version list, so we can build a container for that as well.

/xref https://github.com/pulumi/pulumi-docker-containers/issues/732