### PR TITLE
Add yq to the kitchen sink and per-language Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   releases can no longer be installed that way.
   ([#681](https://github.com/pulumi/pulumi-docker-containers/pull/681))
 
+- Add yq to the go, java, nodejs, python, and dotnet runtime Docker images
+  ([#756](https://github.com/pulumi/pulumi-docker-containers/pull/756))
+
 - Add yq to the `pulumi/pulumi` container
   ([#756](https://github.com/pulumi/pulumi-docker-containers/pull/756))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   releases can no longer be installed that way.
   ([#681](https://github.com/pulumi/pulumi-docker-containers/pull/681))
 
+- Add yq to the `pulumi/pulumi` container
+  ([#756](https://github.com/pulumi/pulumi-docker-containers/pull/756))
+
 ## 3.234
 
 - Include `pulumi-language-bun` in the nodejs images so the Bun language runtime

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -23,7 +23,8 @@ ARG LANGUAGE_VERSION
 RUN apt-get update -y && \
     apt-get install -y \
     git \
-    curl
+    curl \
+    yq
 
 # Install dotnet using instructions from:
 # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -62,6 +62,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache \
     apt-get install -y \
     curl \
     git \
+    yq \
     ca-certificates; \
     mkdir -p /go
 

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl \
     git \
+    yq \
     openjdk-21-jdk \
     maven \
     gradle && \

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && \
     apt-get install -y \
     curl \
     git \
+    yq \
     ca-certificates && \
     npm install -g npm@${NPM_VERSION} bun pnpm@^10 corepack && \
     corepack install -g yarn@1

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update -y && \
   unzip  \
   wget \
   xz-utils \
+  yq \
   zlib1g-dev && \
   rm -rf /var/lib/apt/lists/*
 

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y && \
     apt-get install -y \
     curl \
     git \
+    yq \
     ca-certificates
 
 # Install poetry


### PR DESCRIPTION
We don't have an out-of-the-box way to merge multiple YAML files. Aaron Friel provided [this suggestion](https://github.com/pulumi/pulumi-yaml/issues/227#issuecomment-1930589084) in the past. This PR adds yq to provide that capability in the container images.

Adds yq to:
- The `pulumi/pulumi` kitchen sink image
- Go, Java, Node.js, Python, and .NET language runtime images

Note: The `.ubi` variants and base images were intentionally left untouched, as UBI9/microdnf repositories don't carry a `yq` package like Debian Trixie does.