### PR TITLE
Remove dead go-install custom manager from Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,17 +6,6 @@
     'default:pinDigestsDisabled',
   ],
   customManagers: [
-    // Update `go install <module>@<version>` lines in Dockerfiles.
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/(^|/)Dockerfile$/',
-      ],
-      matchStrings: [
-        'go install (?<depName>[^\\s@]+)@(?<currentValue>v\\S+)',
-      ],
-      datasourceTemplate: 'go',
-    },
     // Update `ENV <NAME>_VERSION <version>` lines in Dockerfiles when
     // preceded by a Renovate inline comment of the form:
     //   # renovate: datasource=<ds> depName=<name> [extractVersion=<re>]


### PR DESCRIPTION
The custom manager matching `go install <module>@<version>` lines in Dockerfiles no longer matches anything. Its only match was the aws-iam-authenticator install in `docker/pulumi/Dockerfile`, which was switched to release binaries in #736. All remaining version pins use the `# renovate:` inline-comment manager instead.