### PR TITLE
Install kubectl from the release binaries so it is version-stamped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Install `kubectl` in the `pulumi/pulumi` image from the upstream release binaries
+  instead of apt, so it is version-stamped. The previous install could resolve to a
+  build reporting `v0.0.0-master+$Format:%H$`, which is not parseable as a version and
+  breaks tooling that checks the kubectl client version, such as `@pulumi/eks`.
+  ([#776](https://github.com/pulumi/pulumi-docker-containers/issues/776))
+
 - Add .NET 10 to the kitchen sink `pulumi/pulumi` image, alongside 8.0 and 9.0
   ([#763](https://github.com/pulumi/pulumi-docker-containers/issues/763))
 

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -71,17 +71,25 @@ RUN \
   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/google-cloud.gpg && \
   echo "deb [arch=${TARGETARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list && \
   echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  KUBE_LATEST=$(curl -L -s https://dl.k8s.io/release/stable.txt | awk 'BEGIN { FS="." } { printf "%s.%s", $1, $2 }') && \
-  curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
-  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list && \
-  # Install azure-cli (from Debian repos), docker, gcloud, kubectl
+  # kubectl, from the official release binaries and verified against the published checksum.
+  # Installed this way rather than from apt so we get a version-stamped build: the Google Cloud
+  # SDK repo added above also publishes a `kubectl` package, and resolving between the two can
+  # yield a binary whose `kubectl version` reports `v0.0.0-master+$Format:%H$`, which breaks any
+  # tooling that parses the client version.
+  KUBE_LATEST=$(curl --proto "=https" --tlsv1.2 --fail --location --silent --show-error https://dl.k8s.io/release/stable.txt) && \
+  KUBECTL_BASE_URL="https://dl.k8s.io/release/${KUBE_LATEST}/bin/linux/${TARGETARCH}" && \
+  curl --proto "=https" --tlsv1.2 --fail --location --remote-name "${KUBECTL_BASE_URL}/kubectl" && \
+  curl --proto "=https" --tlsv1.2 --fail --location --silent --show-error "${KUBECTL_BASE_URL}/kubectl.sha256" \
+    | awk '{print $1"  kubectl"}' | sha256sum --check - && \
+  install --mode 755 kubectl /usr/bin/kubectl && \
+  rm kubectl && \
+  # Install azure-cli (from Debian repos), docker, gcloud
   apt-get update -y && \
   apt-get install -y \
   azure-cli \
   docker-ce \
   google-cloud-cli \
-  google-cloud-cli-gke-gcloud-auth-plugin \
-  kubectl && \
+  google-cloud-cli-gke-gcloud-auth-plugin && \
   rm -rf /var/lib/apt/lists/*
 
 # Install Go

--- a/docker/pulumi/Dockerfile
+++ b/docker/pulumi/Dockerfile
@@ -65,17 +65,7 @@ RUN \
   ./aws/install && \
   rm -rf aws && \
   rm awscliv2.zip && \
-  # Add additional apt repos using modern keyrings approach
-  mkdir -p /etc/apt/keyrings && \
-  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/google-cloud.gpg && \
-  echo "deb [arch=${TARGETARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list && \
-  echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  # kubectl, from the official release binaries and verified against the published checksum.
-  # Installed this way rather than from apt so we get a version-stamped build: the Google Cloud
-  # SDK repo added above also publishes a `kubectl` package, and resolving between the two can
-  # yield a binary whose `kubectl version` reports `v0.0.0-master+$Format:%H$`, which breaks any
-  # tooling that parses the client version.
+  # kubectl from the official release binaries
   KUBE_LATEST=$(curl --proto "=https" --tlsv1.2 --fail --location --silent --show-error https://dl.k8s.io/release/stable.txt) && \
   KUBECTL_BASE_URL="https://dl.k8s.io/release/${KUBE_LATEST}/bin/linux/${TARGETARCH}" && \
   curl --proto "=https" --tlsv1.2 --fail --location --remote-name "${KUBECTL_BASE_URL}/kubectl" && \
@@ -83,6 +73,12 @@ RUN \
     | awk '{print $1"  kubectl"}' | sha256sum --check - && \
   install --mode 755 kubectl /usr/bin/kubectl && \
   rm kubectl && \
+  # Add additional apt repos using modern keyrings approach
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/google-cloud.gpg && \
+  echo "deb [arch=${TARGETARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list && \
+  echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
   # Install azure-cli (from Debian repos), docker, gcloud
   apt-get update -y && \
   apt-get install -y \

--- a/tests/containers_test.go
+++ b/tests/containers_test.go
@@ -377,6 +377,34 @@ func TestCLIToolTests(t *testing.T) {
 		}
 		require.Equal(t, project, projectNumber)
 	})
+
+	// kubectl must report a real, version-stamped build. A build without the version ldflags
+	// reports `v0.0.0-master+$Format:%H$`, which is not parseable as semver and breaks tooling
+	// that checks the client version (for example @pulumi/eks).
+	// https://github.com/pulumi/pulumi-docker-containers/issues/776
+	t.Run("Kubectl", func(t *testing.T) {
+		if !isKitchenSink(t) {
+			t.Skip("kubectl is only installed in the kitchen sink image")
+		}
+		t.Parallel()
+
+		cmd := exec.Command("kubectl", "version", "--client=true", "--output=json")
+		out, err := cmd.Output()
+		require.NoError(t, err)
+
+		var result struct {
+			ClientVersion struct {
+				GitVersion string `json:"gitVersion"`
+			} `json:"clientVersion"`
+		}
+		require.NoError(t, json.Unmarshal(out, &result))
+
+		gitVersion := result.ClientVersion.GitVersion
+		require.NotContains(t, gitVersion, "$Format:",
+			"kubectl is not version-stamped, got gitVersion %q", gitVersion)
+		require.Regexp(t, `^v\d+\.\d+\.\d+`, gitVersion,
+			"kubectl gitVersion %q is not parseable as a version", gitVersion)
+	})
 }
 
 func TestEnvironment(t *testing.T) {


### PR DESCRIPTION
Companion to #777 so CI
  runs with repo secrets — fork PRs can't access the ESC OIDC token. All credit to @rparsonsbb. Fixes #776.